### PR TITLE
use independent network and modify container names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@ bin
 logs
 .devcontainer
 components
-logs
 out-test
 .github
-
+.idea
+.vscode
 tmp

--- a/config/config.docker.yaml
+++ b/config/config.docker.yaml
@@ -1,0 +1,147 @@
+
+# The class cannot be named by Pascal or camel case.
+# If it is not used, the corresponding structure will not be set,
+# and it will not be read naturally.
+serverversion: 1.0.0
+#---------------Infrastructure configuration---------------------#
+etcd:
+  etcdSchema: openIM
+  etcdAddr: [ open_im_etcd:2379 ]
+
+mysql:
+  dbMysqlAddress: [ open_im_mysql:3306 ]
+  dbMysqlUserName: root
+  dbMysqlPassword: openIM
+  dbMysqlDatabaseName: openIM
+  dbTableName: eMsg
+  dbMsgTableNum: 1
+  dbMaxOpenConns: 20
+  dbMaxIdleConns: 10
+  dbMaxLifeTime: 120
+
+mongo:
+  dbAddress: [ open_im_mongodb:27017 ]
+  dbDirect: false
+  dbTimeout: 10
+  dbDatabase: openIM
+  dbSource: admin
+  dbUserName:
+  dbPassword:
+  dbMaxPoolSize: 20
+  dbRetainChatRecords: 7
+
+redis:
+  dbAddress: open_im_redis:6379
+  dbMaxIdle: 128
+  dbMaxActive: 0
+  dbIdleTimeout: 120
+  dbPassWord: openIM
+
+kafka:
+  ws2mschat:
+    addr: [ open_im_kafka:9092 ]
+    topic: "ws2ms_chat"
+  ms2pschat:
+    addr: [ open_im_kafka:9092 ]
+    topic: "ms2ps_chat"
+  consumergroupid:
+    msgToMongo: mongo
+    msgToMySql: mysql
+    msgToPush: push
+
+
+
+#---------------Internal service configuration---------------------#
+
+# The service ip default is empty,
+# automatically obtain the machine's valid network card ip as the service ip,
+# otherwise the configuration ip is preferred
+serverip:
+
+api:
+  openImApiPort: [ 10000 ]
+sdk:
+  openImSdkWsPort: [ 30000 ]
+
+credential:
+  tencent:
+    appID: 1302656840
+    region: ap-chengdu
+    bucket: echat-1302656840
+    secretID: AKIDGNYVChzIQinu7QEgtNp0hnNgqcV8vZTC
+    secretKey: kz15vW83qM6dBUWIq681eBZA0c0vlIbe
+
+
+rpcport:
+  openImUserPort: [ 10100 ]
+  openImFriendPort: [ 10200 ]
+  openImOfflineMessagePort: [ 10300 ]
+  openImOnlineRelayPort: [ 10400 ]
+  openImGroupPort: [ 10500  ]
+  openImAuthPort: [ 10600 ]
+  openImPushPort: [ 10700 ]
+
+
+rpcregistername:
+  openImUserName: User
+  openImFriendName: Friend
+  openImOfflineMessageName: OfflineMessage
+  openImPushName: Push
+  openImOnlineMessageRelayName: OnlineMessageRelay
+  openImGroupName: Group
+  openImAuthName: Auth
+
+log:
+  storageLocation: ../logs/
+  rotationTime: 24
+  remainRotationCount: 5
+  remainLogLevel: 6
+  elasticSearchSwitch: false
+  elasticSearchAddr: [ 127.0.0.1:9201 ]
+  elasticSearchUser: ""
+  elasticSearchPassword: ""
+
+modulename:
+  longConnSvrName: msg_gateway
+  msgTransferName: msg_transfer
+  pushName: push
+
+longconnsvr:
+  openImWsPort: [ 17778 ]
+  websocketMaxConnNum: 10000
+  websocketMaxMsgLen: 4096
+  websocketTimeOut: 10
+
+push:
+  tpns:
+    ios:
+      accessID: 1600018281
+      secretKey: 3cd68a77a95b89e5089a1aca523f318f
+    android:
+      accessID: 111
+      secretKey: 111
+  jpns:
+    appKey: 2783339cee4de379cc798fe1
+    masterSecret: 66e5f309e032c68cc668c28a
+    pushUrl: "https://api.jpush.cn/v3/push"
+manager:
+  appManagerUid: ["openIM123456","openIM654321"]
+  secrets: ["openIM1","openIM2"]
+
+secret: tuoyun
+
+multiloginpolicy:
+  onlyOneTerminalAccess: false
+  mobileAndPCTerminalAccessButOtherTerminalKickEachOther: true
+  allTerminalAccess: false
+
+#token config
+tokenpolicy:
+  accessSecret: "open_im_server"
+  # Token effective time seconds as a unit
+  #Seven days   7*24*60*60
+  accessExpire: 604800
+
+messagecallback:
+  callbackSwitch: false
+  callbackUrl: "http://www.xxx.com/msg/judge"

--- a/config/config.docker.yaml
+++ b/config/config.docker.yaml
@@ -20,7 +20,7 @@ mysql:
   dbMaxLifeTime: 120
 
 mongo:
-  dbAddress: [ open_im_mongodb:27017 ]
+  dbAddress: [ open_im_mongo:27017 ]
   dbDirect: false
   dbTimeout: 10
   dbDatabase: openIM

--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -34,6 +34,27 @@ VOLUME ["/Open-IM-Server/logs","/Open-IM-Server/config","/Open-IM-Server/script"
 COPY --from=build /Open-IM-Server/script /Open-IM-Server/script
 COPY --from=build /Open-IM-Server/bin /Open-IM-Server/bin
 
+# openImApiPort
+EXPOSE 10000
+# openImSdkWsPort
+EXPOSE 30000
+# openImUserPort
+EXPOSE 10100
+# openImFriendPort
+EXPOSE 10200
+# openImOfflineMessagePort
+EXPOSE 10300
+# openImOnlineRelayPort
+EXPOSE 10400
+# openImGroupPort
+EXPOSE 10500
+# openImAuthPort
+EXPOSE 10600
+# openImPushPort
+EXPOSE 10700
+# openImWsPort
+EXPOSE 17778
+
 WORKDIR /Open-IM-Server/script
 
 CMD ["./docker_start_all.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,9 @@ version: "3"
 services:
   mysql:
     image: mysql:5.7
-    ports:
-      - 3306:3306
-    container_name: mysql
+    networks:
+      - open_im_net
+    container_name: open_im_mysql
     volumes:
       - ./components/mysql/data:/var/lib/mysql
       - /etc/localtime:/etc/localtime
@@ -16,9 +16,9 @@ services:
 
   mongodb:
     image: mongo:4.0
-    ports:
-      - 27017:27017
-    container_name: mongo
+    networks:
+      - open_im_net
+    container_name: open_im_mongo
     volumes:
       - ./components/mongodb/data:/data/db
     environment:
@@ -27,9 +27,9 @@ services:
 
   redis:
     image: redis
-    ports:
-      - 6379:6379
-    container_name: redis
+    networks:
+      - open_im_net
+    container_name: open_im_redis
     volumes:
       - ./components/redis/data:/data
       #redis config file
@@ -44,9 +44,9 @@ services:
 
   zookeeper:
     image: wurstmeister/zookeeper
-    ports:
-      - 2181:2181
-    container_name: zookeeper
+    networks:
+      - open_im_net
+    container_name: open_im_zookeeper
     volumes:
       - /etc/localtime:/etc/localtime
     environment:
@@ -56,24 +56,24 @@ services:
 
   kafka:
     image: wurstmeister/kafka
-    container_name: kafka
+    networks:
+      - open_im_net
+    container_name: open_im_kafka
     restart: always
     environment:
       TZ: Asia/Shanghai
       KAFKA_BROKER_ID: 0
-      KAFKA_ZOOKEEPER_CONNECT: 127.0.0.1:2181
+      KAFKA_ZOOKEEPER_CONNECT: open_im_zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-    network_mode: "host"
     depends_on:
       - zookeeper
 
   etcd:
     image: quay.io/coreos/etcd
-    ports:
-      - 2379:2379
-      - 2380:2380
-    container_name: etcd
+    networks:
+      - open_im_net
+    container_name: open_im_etcd
     volumes:
       - /etc/timezone:/etc/timezone
       - /etc/localtime:/etc/localtime
@@ -110,10 +110,10 @@ services:
   #fixme----build from docker hub------
   open-im-server:
     image: lyt1123/open_im_server
-    container_name: open-im-server
+    container_name: open_im_server
     volumes:
       - ./logs:/Open-IM-Server/logs
-      - ./config/config.yaml:/Open-IM-Server/config/config.yaml
+      - ./config/config.docker.yaml:/Open-IM-Server/config/config.yaml
     restart: always
     depends_on:
       - kafka
@@ -121,9 +121,25 @@ services:
       - mongodb
       - redis
       - etcd
-    network_mode: "host"
+    networks:
+      - open_im_net
+    ports:
+      - "10000:10000"
+      - "30000:30000"
+      - "10100:10100"
+      - "10200:10200"
+      - "10300:10300"
+      - "10400:10400"
+      - "10500:10500"
+      - "10600:10600"
+      - "10700:10700"
+      - "17778:17778"
     logging:
       driver: json-file
       options:
         max-size: "1g"
         max-file: "2"
+
+networks:
+  open_im_net:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,7 +64,7 @@ services:
       TZ: Asia/Shanghai
       KAFKA_BROKER_ID: 0
       KAFKA_ZOOKEEPER_CONNECT: open_im_zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://open_im_zookeeper:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
     depends_on:
       - zookeeper

--- a/script/docker_check_service.sh
+++ b/script/docker_check_service.sh
@@ -3,13 +3,13 @@
 source ./style_info.cfg
 
 docker_compose_components=(
-  etcd
-  mongo
-  mysql
-  open-im-server
-  redis
-  kafka
-  zookeeper
+  open_im_etcd
+  open_im_mongo
+  open_im_mysql
+  open_im_server
+  open_im_redis
+  open_im_kafka
+  open_im_zookeeper
 )
 
 component_server_count=0


### PR DESCRIPTION
使用独立内部网络以及修改container名称以避免重复，减少部署出错的可能性。fix #70 