### PR TITLE
fix 单容器单进程部署方式时对注册到etcd的各组件ip的读取为本地ip的问题

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,6 +58,7 @@ kafka:
 serverip: 0.0.0.0
 
 # endpoints 内部组件间访问的端点host名称，访问时，可以内部直接访问 host:port 来访问
+# 如果需要使用ip访问（比如在单容器里面运行所有组件时），可以直接把下列名称直接改为ip地址（比如0.0.0.0）
 endpoints:
   api: openim_api
   cmsapi: openim_cms_api

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -7,11 +7,9 @@ SKY_BLUE_PREFIX="\033[36m"
 # 编译所有需要的组件源码
 win-build-all:
 	go env -w GOOS=linux 
-
 	make build-api && make build-msg-gateway && make build-msg-transfer  && make build-push && make build-timer-task
 	make build-rpc-user && make build-rpc-friend && make build-rpc-group && make build-rpc-msg && make build-rpc-auth
 	make build-demo
-
 	go env -w GOOS=windows
 
 # 编译 open_im_api

--- a/deploy/dockerfiles/Dockerfile.sdk
+++ b/deploy/dockerfiles/Dockerfile.sdk
@@ -1,0 +1,23 @@
+FROM alpine:3.13
+
+# 设置固定的项目路径
+ENV WORKDIR /app
+ENV CONFIG_NAME $WORKDIR/config/config.yaml
+
+# 定义环境变量
+ARG API_ENDPOINT=0.0.0.0:10000
+ENV API_ENDPOINT ${API_ENDPOINT}
+
+ARG WS_ENDPOINT=0.0.0.0:17778
+ENV WS_ENDPOINT ${WS_ENDPOINT}
+
+# 将可执行文件复制到目标目录
+ADD ./open_im_sdk_server $WORKDIR/main
+
+# 创建用于挂载的几个目录，添加可执行权限
+RUN mkdir $WORKDIR/logs $WORKDIR/config $WORKDIR/db && \
+  chmod +x $WORKDIR/main
+
+
+WORKDIR $WORKDIR
+CMD ./main

--- a/deploy/openim.yaml
+++ b/deploy/openim.yaml
@@ -1,4 +1,5 @@
 version: "3.7"
+#fixme  Clone openIM Server project before using docker-compose,project address：https://github.com/OpenIMSDK/Open-IM-Server.git
 networks: 
   openim:
     external: true
@@ -15,7 +16,6 @@ services:
       - ./logs:/app/logs
       # Dockerfile 里定义了配置文件的路径环境变量，CONFIG_NAME，默认指向了 /app/config/config.yaml
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
     # depends_on:
     #   - kafka
@@ -23,6 +23,30 @@ services:
     #   # - mongodb
     #   - redis
     #   - etcd
+    logging:
+      driver: json-file
+      options:
+        max-size: "1g"
+        max-file: "2"
+
+# 如果需要sdk，则可以拉起
+  sdk:
+    networks: 
+      - openim
+    image: openim/sdk
+    container_name: openim_sdk
+    ports:
+      - 30000:30000 # sdk，必须开
+    environment:
+      - "API_ENDPOINT=http://openim_api:10000"
+      - "WS_ENDPOINT=http://openim_msg_gateway:17778"
+    volumes:
+      - ./logs:/app/logs
+      - ./db/sdk:/app/db/sdk
+    restart: always
+    depends_on:
+      - api
+      - msg_gateway
     logging:
       driver: json-file
       options:
@@ -39,14 +63,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
     logging:
       driver: json-file
       options:
@@ -61,14 +78,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
     logging:
       driver: json-file
       options:
@@ -83,14 +93,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
     logging:
       driver: json-file
       options:
@@ -105,7 +108,6 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
     # depends_on:
     #   - kafka
@@ -127,14 +129,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
     logging:
       driver: json-file
       options:
@@ -149,14 +144,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
 
   rpc_group:
     networks: 
@@ -166,14 +154,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
 
   rpc_auth:
     networks: 
@@ -183,14 +164,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
 
   rpc_msg:
     networks: 
@@ -200,14 +174,7 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always
-    # depends_on:
-    #   - kafka
-    #   # - mysql
-    #   # - mongodb
-    #   - redis
-    #   - etcd
 
   demo:
     networks: 
@@ -219,5 +186,4 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config/config.yaml:/app/config/config.yaml
-      - ./db/sdk:/app/db/sdk
     restart: always

--- a/deploy/readme.md
+++ b/deploy/readme.md
@@ -3,8 +3,8 @@
 ```sh
 # 查看 ./Makefile ，先编译各个需要的源码到 ../bin 
 
-# 目前没有处理 Open-IM-SDK-Core ，如果需要的话，建议单独拉取代码，然后执行其Makefile中的命令编译打包镜像
-# make build-win
+# 目前没有处理 Open-IM-SDK-Core ，如果需要的话，建议单独拉取代码，然后执行其Makefile中的命令编译打包镜像,sdk目前依赖sqlite，需要启用cgo，目前测试通过的是在linux环境编译,win下可以在wsl中执行编译
+# make build-linux
 # make build-image
 
 # win-* 表示在win平台编译位linux二进制，其实就是处理了 go env -w GOOS=linux 

--- a/deploy/readme.md
+++ b/deploy/readme.md
@@ -2,11 +2,15 @@
 ### 以docker-compose 形式单独部署
 ```sh
 # 查看 ./Makefile ，先编译各个需要的源码到 ../bin 
+
+# 目前没有处理 Open-IM-SDK-Core ，如果需要的话，建议单独拉取代码，然后执行其Makefile中的命令编译打包镜像
+# make build-win
+# make build-image
+
 # win-* 表示在win平台编译位linux二进制，其实就是处理了 go env -w GOOS=linux 
 make win-build-all
 
 # 得到各个二进制程序之后，打包为镜像
-# 目前没有处理 Open-IM-SDK-Core ，需要的话可以自己单独处理这个模块
 make image-all
 
 # docker-compose.yaml 分成了两部分，一部分是openIM的镜像容器 openim.yaml，一部分是依赖的环境 env.yaml

--- a/internal/api/third/minio_storage_credential.go
+++ b/internal/api/third/minio_storage_credential.go
@@ -6,13 +6,14 @@ import (
 	http "Open_IM/pkg/common/http"
 	"Open_IM/pkg/common/log"
 	"Open_IM/pkg/common/token_verify"
+
 	"github.com/gin-gonic/gin"
-	_ cr "github.com/minio/minio-go/v7/pkg/credentials"
+	_ "github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 func MinioStorageCredential(c *gin.Context) {
 	var (
-		req apiStruct.MinioStorageCredentialReq
+		req  apiStruct.MinioStorageCredentialReq
 		resp apiStruct.MiniostorageCredentialResp
 	)
 	ok, _ := token_verify.GetUserIDFromToken(c.Request.Header.Get("token"))

--- a/internal/demo/register/login.go
+++ b/internal/demo/register/login.go
@@ -7,11 +7,12 @@ import (
 	"Open_IM/pkg/common/db/mysql_model/im_mysql_model"
 	http2 "Open_IM/pkg/common/http"
 	"Open_IM/pkg/common/log"
-	"Open_IM/pkg/utils"
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
 )
 
 type ParamsLogin struct {
@@ -46,7 +47,7 @@ func Login(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"errCode": constant.PasswordErr, "errMsg": "Mobile phone number is not registered"})
 		return
 	}
-	url := fmt.Sprintf("http://%s:10000/auth/user_token", utils.ServerIP)
+	url := fmt.Sprintf("http://%s:10000/auth/user_token", viper.GetString("endpoints.api"))
 	openIMGetUserToken := api.UserTokenReq{}
 	openIMGetUserToken.OperationID = params.OperationID
 	openIMGetUserToken.Platform = params.Platform

--- a/internal/demo/register/set_password.go
+++ b/internal/demo/register/set_password.go
@@ -8,12 +8,13 @@ import (
 	"Open_IM/pkg/common/db/mysql_model/im_mysql_model"
 	http2 "Open_IM/pkg/common/http"
 	"Open_IM/pkg/common/log"
-	"Open_IM/pkg/utils"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/garyburd/redigo/redis"
 	"github.com/gin-gonic/gin"
-	"net/http"
+	"github.com/spf13/viper"
 )
 
 type ParamsSetPassword struct {
@@ -48,7 +49,7 @@ func SetPassword(c *gin.Context) {
 			return
 		}
 	}
-	url := fmt.Sprintf("http://%s:10000/auth/user_register", utils.ServerIP)
+	url := fmt.Sprintf("http://%s:10000/auth/user_register", viper.GetString("endpoints.api"))
 	openIMRegisterReq := api.UserRegisterReq{}
 	openIMRegisterReq.OperationID = params.OperationID
 	openIMRegisterReq.Platform = params.Platform

--- a/internal/msg_gateway/gate/rpc_server.go
+++ b/internal/msg_gateway/gate/rpc_server.go
@@ -12,9 +12,11 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
-	"github.com/golang/protobuf/proto"
 	"net"
 	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/spf13/viper"
 
 	"github.com/gorilla/websocket"
 	"google.golang.org/grpc"
@@ -45,7 +47,8 @@ func (r *RPCServer) run() {
 	srv := grpc.NewServer()
 	defer srv.GracefulStop()
 	pbRelay.RegisterOnlineMessageRelayServiceServer(srv, r)
-	err = getcdv3.RegisterEtcd4Unique(r.etcdSchema, strings.Join(r.etcdAddr, ","), ip, r.rpcPort, r.rpcRegisterName, 10)
+	host := viper.GetString("endpoints.msg_gateway")
+	err = getcdv3.RegisterEtcd4Unique(r.etcdSchema, strings.Join(r.etcdAddr, ","), host, r.rpcPort, r.rpcRegisterName, 10)
 	if err != nil {
 		log.ErrorByKv("register push message rpc to etcd err", "", "err", err.Error())
 	}

--- a/internal/push/logic/push_rpc_server.go
+++ b/internal/push/logic/push_rpc_server.go
@@ -4,12 +4,14 @@ import (
 	"Open_IM/pkg/common/config"
 	"Open_IM/pkg/common/log"
 	"Open_IM/pkg/grpc-etcdv3/getcdv3"
-	"Open_IM/pkg/proto/push"
+	pbPush "Open_IM/pkg/proto/push"
 	"Open_IM/pkg/utils"
 	"context"
-	"google.golang.org/grpc"
 	"net"
 	"strings"
+
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
 type RPCServer struct {
@@ -37,7 +39,8 @@ func (r *RPCServer) run() {
 	srv := grpc.NewServer()
 	defer srv.GracefulStop()
 	pbPush.RegisterPushMsgServiceServer(srv, r)
-	err = getcdv3.RegisterEtcd(r.etcdSchema, strings.Join(r.etcdAddr, ","), ip, r.rpcPort, r.rpcRegisterName, 10)
+	host := viper.GetString("endpoints.push")
+	err = getcdv3.RegisterEtcd(r.etcdSchema, strings.Join(r.etcdAddr, ","), host, r.rpcPort, r.rpcRegisterName, 10)
 	if err != nil {
 		log.ErrorByKv("register push module  rpc to etcd err", "", "err", err.Error())
 	}

--- a/internal/rpc/auth/auth.go
+++ b/internal/rpc/auth/auth.go
@@ -16,6 +16,7 @@ import (
 
 	"Open_IM/pkg/common/config"
 
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 )
 
@@ -88,10 +89,11 @@ func (rpc *rpcAuth) Run() {
 
 	//service registers with etcd
 	pbAuth.RegisterAuthServer(srv, rpc)
-	err = getcdv3.RegisterEtcd(rpc.etcdSchema, strings.Join(rpc.etcdAddr, ","), utils.ServerIP, rpc.rpcPort, rpc.rpcRegisterName, 10)
+	host := viper.GetString("endpoints.rpc_auth")
+	err = getcdv3.RegisterEtcd(rpc.etcdSchema, strings.Join(rpc.etcdAddr, ","), host, rpc.rpcPort, rpc.rpcRegisterName, 10)
 	if err != nil {
 		log.NewError("0", "RegisterEtcd failed ", err.Error(),
-			rpc.etcdSchema, strings.Join(rpc.etcdAddr, ","), utils.ServerIP, rpc.rpcPort, rpc.rpcRegisterName)
+			rpc.etcdSchema, strings.Join(rpc.etcdAddr, ","), host, rpc.rpcPort, rpc.rpcRegisterName)
 		return
 	}
 	log.NewInfo("0", "RegisterAuthServer ok ", rpc.etcdSchema, strings.Join(rpc.etcdAddr, ","), utils.ServerIP, rpc.rpcPort, rpc.rpcRegisterName)

--- a/internal/rpc/friend/firend.go
+++ b/internal/rpc/friend/firend.go
@@ -14,11 +14,13 @@ import (
 	sdkws "Open_IM/pkg/proto/sdk_ws"
 	"Open_IM/pkg/utils"
 	"context"
-	"google.golang.org/grpc"
 	"net"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
 type friendServer struct {
@@ -56,7 +58,8 @@ func (s *friendServer) Run() {
 	defer srv.GracefulStop()
 	//User friend related services register to etcd
 	pbFriend.RegisterFriendServer(srv, s)
-	err = getcdv3.RegisterEtcd(s.etcdSchema, strings.Join(s.etcdAddr, ","), ip, s.rpcPort, s.rpcRegisterName, 10)
+	host := viper.GetString("endpoints.rpc_friend")
+	err = getcdv3.RegisterEtcd(s.etcdSchema, strings.Join(s.etcdAddr, ","), host, s.rpcPort, s.rpcRegisterName, 10)
 	if err != nil {
 		log.NewError("0", "RegisterEtcd failed ", err.Error(), s.etcdSchema, strings.Join(s.etcdAddr, ","), ip, s.rpcPort, s.rpcRegisterName)
 		return

--- a/internal/rpc/msg/rpcChat.go
+++ b/internal/rpc/msg/rpcChat.go
@@ -7,10 +7,12 @@ import (
 	"Open_IM/pkg/grpc-etcdv3/getcdv3"
 	pbChat "Open_IM/pkg/proto/chat"
 	"Open_IM/pkg/utils"
-	"google.golang.org/grpc"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
 type rpcChat struct {
@@ -51,7 +53,8 @@ func (rpc *rpcChat) Run() {
 	//service registers with etcd
 
 	pbChat.RegisterChatServer(srv, rpc)
-	err = getcdv3.RegisterEtcd(rpc.etcdSchema, strings.Join(rpc.etcdAddr, ","), utils.ServerIP, rpc.rpcPort, rpc.rpcRegisterName, 10)
+	host := viper.GetString("endpoints.rpc_msg")
+	err = getcdv3.RegisterEtcd(rpc.etcdSchema, strings.Join(rpc.etcdAddr, ","), host, rpc.rpcPort, rpc.rpcRegisterName, 10)
 	if err != nil {
 		log.Error("", "", "register rpc get_token to etcd failed, err = %s", err.Error())
 		return

--- a/internal/rpc/user/user.go
+++ b/internal/rpc/user/user.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 )
 
@@ -59,7 +60,8 @@ func (s *userServer) Run() {
 	defer srv.GracefulStop()
 	//Service registers with etcd
 	pbUser.RegisterUserServer(srv, s)
-	err = getcdv3.RegisterEtcd(s.etcdSchema, strings.Join(s.etcdAddr, ","), ip, s.rpcPort, s.rpcRegisterName, 10)
+	host := viper.GetString("endpoints.rpc_user")
+	err = getcdv3.RegisterEtcd(s.etcdSchema, strings.Join(s.etcdAddr, ","), host, s.rpcPort, s.rpcRegisterName, 10)
 	if err != nil {
 		log.NewError("0", "RegisterEtcd failed ", err.Error(), s.etcdSchema, strings.Join(s.etcdAddr, ","), ip, s.rpcPort, s.rpcRegisterName)
 		return

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -344,5 +343,4 @@ func init() {
 	if err = yaml.Unmarshal(bytes, &Config); err != nil {
 		panic(err.Error())
 	}
-	fmt.Println("load config: ", Config)
 }

--- a/pkg/utils/get_server_ip.go
+++ b/pkg/utils/get_server_ip.go
@@ -5,6 +5,12 @@ import (
 	"net"
 )
 
+// Deprecated: This value is no longer recommended.
+// 不在建议使用该值：主要因为该值在每个组件部署时无法表示各自的实际ip，建议使用viper读取目标配置
+//
+// 比如：
+//
+// 需要读取rpc_auth地址时：viper.GetString("endpoints.rpc_auth")
 var ServerIP = ""
 
 func init() {


### PR DESCRIPTION
1、fix 单容器单进程部署方式时对注册到etcd的各组件ip的读取为本地ip的问题（单容器单进程方式时，每个组件的ip都不一样，此时不能直接读取本容器ip，现在改成了读取环境变量）
2、补充了一些deploy下的部署说明、注释