### PR TITLE
管理员创建群组bug fix

### DIFF
--- a/internal/api/group/group.go
+++ b/internal/api/group/group.go
@@ -260,6 +260,10 @@ func CreateGroup(c *gin.Context) {
 		return
 	}
 	req.OwnerUserID = req.OpUserID
+	if params.OwnerUserID != "" {
+		req.OwnerUserID = params.OwnerUserID
+	}
+
 	req.OperationID = params.OperationID
 	log.NewInfo(req.OperationID, "CreateGroup args ", req.String())
 


### PR DESCRIPTION
管理员创建群组时传过来的ownerUserID,可能和token里解析的不一致，如果params里OwnerUserID不为空，则应该以传入的为主