### PR TITLE
k8s部署基础镜像建议修改

### DIFF
--- a/deploy_k8s/admin_cms/admin_cms.Dockerfile
+++ b/deploy_k8s/admin_cms/admin_cms.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/api/api.Dockerfile
+++ b/deploy_k8s/api/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/auth/auth.Dockerfile
+++ b/deploy_k8s/auth/auth.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/cache/cache.Dockerfile
+++ b/deploy_k8s/cache/cache.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/cms_api/cms_api.Dockerfile
+++ b/deploy_k8s/cms_api/cms_api.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/conversation/conversation.Dockerfile
+++ b/deploy_k8s/conversation/conversation.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/demo/demo.Dockerfile
+++ b/deploy_k8s/demo/demo.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/friend/friend.Dockerfile
+++ b/deploy_k8s/friend/friend.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/group/group.Dockerfile
+++ b/deploy_k8s/group/group.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/msg/msg.Dockerfile
+++ b/deploy_k8s/msg/msg.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/msg_gateway/msg_gateway.Dockerfile
+++ b/deploy_k8s/msg_gateway/msg_gateway.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/msg_transfer/msg_transfer.Dockerfile
+++ b/deploy_k8s/msg_transfer/msg_transfer.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/office/office.Dockerfile
+++ b/deploy_k8s/office/office.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/organization/organization.Dockerfile
+++ b/deploy_k8s/organization/organization.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/push/push.Dockerfile
+++ b/deploy_k8s/push/push.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/sdk_server/sdk_server.Dockerfile
+++ b/deploy_k8s/sdk_server/sdk_server.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server

--- a/deploy_k8s/user/user.Dockerfile
+++ b/deploy_k8s/user/user.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM buildpack-deps:bullseye-curl
 
 # 设置固定的项目路径
 ENV WORKDIR /Open-IM-Server


### PR DESCRIPTION
k8s部署基础镜像建议从ubuntu改为buildpack-deps:bullseye-curl
基础镜像ubuntu不包含根证书,如果配置第三方推送例如getui,会导致发生证书错误