### PR TITLE
fix: Implement Enhanced File Descriptor Limit Handling in Shell Script

### DIFF
--- a/scripts/install/openim-msggateway.sh
+++ b/scripts/install/openim-msggateway.sh
@@ -18,10 +18,10 @@ set -o errexit
 set +o nounset
 set -o pipefail
 
-ulimit -n 200000
-
 OPENIM_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)
 [[ -z ${COMMON_SOURCED} ]] && source "${OPENIM_ROOT}"/scripts/install/common.sh
+
+openim::util::set_max_fd 200000
 
 SERVER_NAME="openim-msggateway"
 

--- a/scripts/install/openim-msgtransfer.sh
+++ b/scripts/install/openim-msgtransfer.sh
@@ -18,10 +18,10 @@ set -o errexit
 set +o nounset
 set -o pipefail
 
-ulimit -n 200000
-
 OPENIM_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)
 [[ -z ${COMMON_SOURCED} ]] && source "${OPENIM_ROOT}"/scripts/install/common.sh
+
+openim::util::set_max_fd 200000
 
 SERVER_NAME="openim-msgtransfer"
 


### PR DESCRIPTION
<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
#### 🔍 What type of PR is this?
/kind documentation
/kind feature

<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

<!--Why do we need this PR?-->

This PR introduces an enhancement to the shell script responsible for managing the file descriptor limit of the process. This is crucial for applications that require handling numerous simultaneous file operations, ensuring smooth performance without hitting the default system limit.

Changes included:

+ A new function `set_max_fd()` that dynamically sets the file descriptor limit based on user input and system maximum permissible values.
+ Conditional checks to ensure compatibility and appropriate handling for different operating systems (excluding Darwin and Cygwin due to their distinct management of file descriptors).
+ Warning messages to alert users when desired limits cannot be set, providing insights into potential issues.
+ An example usage of the `set_max_fd()` function, demonstrating how to integrate it into existing scripts.

The new function aims to automatically set the file descriptor limit (`ulimit -n`) for the running shell process, either to a user-defined value or to the maximum allowed by the system. It performs checks and validations to ensure the requested limit is permissible and provides feedback when actions cannot be performed.

#### 🅰 Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If there are multiple PRS, use `Resolves #10, resolves #123, resolves octo-org/octo-repo#100`
If there is a relevant PR, use `octo-org/octo-repo#123`
-->

Fixes #1158

#### 📝 Special notes for your reviewer:

no

<!-- What else would you tell someone who reviews your code -->

#### 🎯 Describe how to verify it

```bash
make start
```

<!-- Make sure to execute it `make all` locally, and it passed the test.-->

