### PR TITLE
feat: add redis cluster mode in option

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -224,6 +224,7 @@ config/config.yaml 文件为存储组件提供了详细的配置说明。
 
     ```
     redis:
+      clusterMode: false                      #是否为 redis cluster 模式
       address: [ 127.0.0.1:16379 ]            #地址
       username:                               #用户名
       password: openIM123                     #密码

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -75,9 +75,10 @@ type configStruct struct {
 	} `yaml:"mongo"`
 
 	Redis struct {
-		Address  []string `yaml:"address"`
-		Username string   `yaml:"username"`
-		Password string   `yaml:"password"`
+		ClusterMode bool     `yaml:"clusterMode"`
+		Address     []string `yaml:"address"`
+		Username    string   `yaml:"username"`
+		Password    string   `yaml:"password"`
 	} `yaml:"redis"`
 
 	Kafka struct {

--- a/pkg/common/db/cache/init_redis.go
+++ b/pkg/common/db/cache/init_redis.go
@@ -39,7 +39,7 @@ func NewRedis() (redis.UniversalClient, error) {
 	}
 	specialerror.AddReplace(redis.Nil, errs.ErrRecordNotFound)
 	var rdb redis.UniversalClient
-	if len(config.Config.Redis.Address) > 1 {
+	if len(config.Config.Redis.Address) > 1 || config.Config.Redis.ClusterMode {
 		rdb = redis.NewClusterClient(&redis.ClusterOptions{
 			Addrs:      config.Config.Redis.Address,
 			Username:   config.Config.Redis.Username,
@@ -58,12 +58,13 @@ func NewRedis() (redis.UniversalClient, error) {
 		})
 	}
 
-	var err error = nil
+	var err error
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	err = rdb.Ping(ctx).Err()
 	if err != nil {
 		return nil, fmt.Errorf("redis ping %w", err)
 	}
+
 	return rdb, err
 }


### PR DESCRIPTION
### summary

In redis cluster mode, we only need a dns lb resolver redis cluster address, that is, an address. Then the mapping of all slot-redis instances is obtained by metadata through the cluster protocol.

So a new parameter is added, clusterMode bool.

In addition, lint changed it a little bit as a lint.

Fix: #1186