### PR TITLE
Ensure Script Compatibility Across Different Bash Versions

### DIFF
--- a/scripts/lib/color.sh
+++ b/scripts/lib/color.sh
@@ -20,7 +20,7 @@
 ################################################################################
 
 # shellcheck disable=SC2034
-if [[ ! -v COLOR_OPEN ]]; then
+if [ -z "${COLOR_OPEN+x}" ]; then
     COLOR_OPEN=1
 fi
 


### PR DESCRIPTION
Replaced the `-v` operator with a more universally compatible method for variable checking in the bash script. The update uses parameter expansion to check if a variable is set, ensuring the script runs smoothly on environments with different Bash versions.

Issue: https://github.com/openimsdk/open-im-server/issues/1182

<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
#### 🔍 What type of PR is this?
/kind bug
<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

<!--Why do we need this PR?-->


#### 🅰 Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If there are multiple PRS, use `Resolves #10, resolves #123, resolves octo-org/octo-repo#100`
If there is a relevant PR, use `octo-org/octo-repo#123`
-->

Fixes #1182



### What Has Changed

+ Updated the method used to check if a variable is set within the bash script. Previously, the `-v` operator was used which is not supported in some Bash versions, leading to an error in certain environments.

### Why Change It

+ The use of the `-v` operator can lead to errors in environments using an older Bash version or different shells, hampering the script's reliability and portability.
+ Implementing a more universally compatible variable checking method allows our script to operate consistently across various environments, increasing its robustness and usability.

### How the Change Has Been Implemented

+ Replaced instances of the `-v` operator with a more traditionally compatible method, using parameter expansion.

### Test and Verification

+ The updated script has been tested in environments with different Bash versions to ensure compatibility and functionality.

### Example:

```
# Replacing:
# if [[ ! -v COLOR_OPEN ]]; then

# With:
if [ -z "${COLOR_OPEN+x}" ]; then
    COLOR_OPEN=1
fi
```

**Linked Issue**: [If there’s an associated issue/ticket, reference it here]

**Testing Procedures**: Provide detailed instructions on how the changes have been tested and verified. Specify environments, tools, and scenarios used for testing.

**Screenshots**: Include any screenshots or GIFs if they provide relevant visual context.

**Additional Context**: Add any other context or information to help reviewers understand the changes and their impact.