### PR TITLE
fix: create database name

### DIFF
--- a/pkg/common/db/relation/mysql_init_test.go
+++ b/pkg/common/db/relation/mysql_init_test.go
@@ -1,0 +1,121 @@
+package relation
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestMaybeCreateTable(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		err := maybeCreateTable(&option{
+			Username:      "root",
+			Password:      "openIM123",
+			Address:       []string{"172.28.0.1:13306"},
+			Database:      "openIM_v3",
+			LogLevel:      4,
+			SlowThreshold: 500,
+			MaxOpenConn:   1000,
+			MaxIdleConn:   100,
+			MaxLifeTime:   60,
+			Connect: connect(expectExec{
+				query: "CREATE DATABASE IF NOT EXISTS `openIM_v3` default charset utf8mb4 COLLATE utf8mb4_unicode_ci",
+				args:  nil,
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("im-db", func(t *testing.T) {
+		err := maybeCreateTable(&option{
+			Username:      "root",
+			Password:      "openIM123",
+			Address:       []string{"172.28.0.1:13306"},
+			Database:      "im-db",
+			LogLevel:      4,
+			SlowThreshold: 500,
+			MaxOpenConn:   1000,
+			MaxIdleConn:   100,
+			MaxLifeTime:   60,
+			Connect: connect(expectExec{
+				query: "CREATE DATABASE IF NOT EXISTS `im-db` default charset utf8mb4 COLLATE utf8mb4_unicode_ci",
+				args:  nil,
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("err", func(t *testing.T) {
+		e := errors.New("e")
+		err := maybeCreateTable(&option{
+			Username:      "root",
+			Password:      "openIM123",
+			Address:       []string{"172.28.0.1:13306"},
+			Database:      "openIM_v3",
+			LogLevel:      4,
+			SlowThreshold: 500,
+			MaxOpenConn:   1000,
+			MaxIdleConn:   100,
+			MaxLifeTime:   60,
+			Connect: connect(expectExec{
+				err: e,
+			}),
+		})
+		if !errors.Is(err, e) {
+			t.Fatalf("err not is e: %v", err)
+		}
+	})
+}
+
+func connect(e expectExec) func(string, int) (*gorm.DB, error) {
+	return func(string, int) (*gorm.DB, error) {
+		return gorm.Open(mysql.New(mysql.Config{
+			SkipInitializeWithVersion: true,
+			Conn:                      sql.OpenDB(e),
+		}), &gorm.Config{
+			Logger: logger.Discard,
+		})
+	}
+}
+
+type expectExec struct {
+	err   error
+	query string
+	args  []driver.NamedValue
+}
+
+func (c expectExec) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	if query != c.query {
+		return nil, fmt.Errorf("query mismatch. expect: %s, got: %s", c.query, query)
+	}
+	if reflect.DeepEqual(args, c.args) {
+		return nil, fmt.Errorf("args mismatch. expect: %v, got: %v", c.args, args)
+	}
+	return noEffectResult{}, nil
+}
+
+func (e expectExec) Connect(context.Context) (driver.Conn, error) { return e, nil }
+func (expectExec) Driver() driver.Driver                          { panic("not implemented") }
+func (expectExec) Prepare(query string) (driver.Stmt, error)      { panic("not implemented") }
+func (expectExec) Close() (e error)                               { return }
+func (expectExec) Begin() (driver.Tx, error)                      { panic("not implemented") }
+
+type noEffectResult struct{}
+
+func (noEffectResult) LastInsertId() (i int64, e error) { return }
+func (noEffectResult) RowsAffected() (i int64, e error) { return }


### PR DESCRIPTION
<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
#### 🔍 What type of PR is this?
<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

<!--Why do we need this PR?-->
It will failed when you init app with a custom database name which contains '-' (eg: "im-db").

```
Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-db default charset utf8mb4 COLLATE utf8mb4_unicode_ci' at line 1
[0.236ms] [rows:0] CREATE DATABASE IF NOT EXISTS im-db default charset utf8mb4 COLLATE utf8mb4_unicode_ci;
```

Screenshot:
![image](https://github.com/openimsdk/open-im-server/assets/56432636/0ba24c6b-0553-4812-9ce6-e69976af018c)

#### 🅰 Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If there are multiple PRS, use `Resolves #10, resolves #123, resolves octo-org/octo-repo#100`
If there is a relevant PR, use `octo-org/octo-repo#123`
-->

Fixes #

#### 📝 Special notes for your reviewer:

<!-- What else would you tell someone who reviews your code -->
* Added a new test.
* Added a new type `option`.
* Note `defer sqlDB.Close()` has been moved.

#### 🎯 Describe how to verify it

<!-- Make sure to execute it `make all` locally, and it passed the test.-->
`go test -run ^TestMaybeCreateTable$ github.com/openimsdk/open-im-server/v3/pkg/common/db/relation`

#### 📑 Additional documentation e.g., RFC, notion, Google docs, usage docs, etc.:


<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

In the sharers Guide, we recommend the following documents:
1. Using GitHub RFCs template: https://github.com/OpenIMSDK/community/blob/main/0000-template.md
2. Use Google Docs OR Notion and share it with the community.
-->
