### PR TITLE
refactor: crontask cmd

### DIFF
--- a/internal/tools/cron_task_test.go
+++ b/internal/tools/cron_task_test.go
@@ -1,0 +1,81 @@
+package tools
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openimsdk/open-im-server/v3/pkg/common/config"
+	"github.com/redis/go-redis/v9"
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisLock(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{})
+	defer rdb.Close()
+
+	assert.Equal(t, true, netlock(rdb, "cron-1", 1*time.Second))
+
+	// if exists, get false
+	assert.Equal(t, false, netlock(rdb, "cron-1", 1*time.Second))
+
+	time.Sleep(2 * time.Second)
+
+	// wait for key on timeout, get true
+	assert.Equal(t, true, netlock(rdb, "cron-1", 2*time.Second))
+
+	// set different key
+	assert.Equal(t, true, netlock(rdb, "cron-2", 2*time.Second))
+}
+
+func TestCronWrapFunc(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{})
+	defer rdb.Close()
+
+	once := sync.Once{}
+	done := make(chan struct{}, 1)
+	cb := func() {
+		once.Do(func() {
+			close(done)
+		})
+	}
+
+	start := time.Now()
+	key := fmt.Sprintf("cron-%v", rand.Int31())
+	crontab := cron.New(cron.WithSeconds())
+	crontab.AddFunc("*/1 * * * * *", cronWrapFunc(rdb, key, cb))
+	crontab.Start()
+	<-done
+
+	dur := time.Since(start)
+	assert.LessOrEqual(t, dur.Seconds(), float64(2*time.Second))
+	crontab.Stop()
+}
+
+func TestCronWrapFuncWithNetlock(t *testing.T) {
+	config.Config.EnableCronLocker = true
+	rdb := redis.NewClient(&redis.Options{})
+	defer rdb.Close()
+
+	done := make(chan string, 10)
+
+	crontab := cron.New(cron.WithSeconds())
+
+	key := fmt.Sprintf("cron-%v", rand.Int31())
+	crontab.AddFunc("*/1 * * * * *", cronWrapFunc(rdb, key, func() {
+		done <- "host1"
+	}))
+	crontab.AddFunc("*/1 * * * * *", cronWrapFunc(rdb, key, func() {
+		done <- "host2"
+	}))
+	crontab.Start()
+
+	time.Sleep(12 * time.Second)
+	// the ttl of netlock is 5s, so expected value is 2.
+	assert.Equal(t, len(done), 2)
+
+	crontab.Stop()
+}

--- a/internal/tools/msg_doc_convert.go
+++ b/internal/tools/msg_doc_convert.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openimsdk/open-im-server/v3/pkg/msgprocessor"
 )
 
-func (c *MsgTool) ConvertTools() {
+func (c *MsgTool) convertTools() {
 	ctx := mcontext.NewCtx("convert")
 	conversationIDs, err := c.conversationDatabase.GetAllConversationIDs(ctx)
 	if err != nil {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -232,6 +232,7 @@ type configStruct struct {
 	ChatRecordsClearTime              string `yaml:"chatRecordsClearTime"`
 	MsgDestructTime                   string `yaml:"msgDestructTime"`
 	Secret                            string `yaml:"secret"`
+	EnableCronLocker                  bool   `yaml:"enableCronLocker"`
 	TokenPolicy                       struct {
 		Expire int64 `yaml:"expire"`
 	} `yaml:"tokenPolicy"`

--- a/pkg/common/db/cache/init_redis.go
+++ b/pkg/common/db/cache/init_redis.go
@@ -28,12 +28,21 @@ import (
 	"github.com/openimsdk/open-im-server/v3/pkg/common/config"
 )
 
+var (
+	// singleton pattern.
+	redisClient redis.UniversalClient
+)
+
 const (
 	maxRetry = 10 // number of retries
 )
 
 // NewRedis Initialize redis connection.
 func NewRedis() (redis.UniversalClient, error) {
+	if redisClient != nil {
+		return redisClient, nil
+	}
+
 	if len(config.Config.Redis.Address) == 0 {
 		return nil, errors.New("redis address is empty")
 	}
@@ -66,5 +75,6 @@ func NewRedis() (redis.UniversalClient, error) {
 		return nil, fmt.Errorf("redis ping %w", err)
 	}
 
+	redisClient = rdb
 	return rdb, err
 }


### PR DESCRIPTION
### summary

1. 重构了 cron_task 的启动代码, 加入了信号处理.
2. 通过分布式锁来实现 crontask 服务在分布式环境并发执行多次的问题。

> 通常为了 HA，cron 服务会多实例部署，但 cron 注册的任务同一时间只需要执行一次即可，无需多个实例执行。 

😁 (如果不需要这个分布式功能，我可以 reset 掉 )  