### PR TITLE
perf: redis block with keys command

### DIFF
--- a/pkg/common/db/cache/msg_test.go
+++ b/pkg/common/db/cache/msg_test.go
@@ -385,3 +385,50 @@ func testParallelDeleteMessagesMix(t *testing.T, cid string, seqs []int64, input
 		assert.EqualValues(t, 1, val) // exists
 	}
 }
+
+func TestCleanUpOneConversationAllMsg(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{})
+	defer rdb.Close()
+
+	cacher := msgCache{rdb: rdb}
+	count := 1000
+	prefix := fmt.Sprintf("%v", rand.Int63())
+
+	ids := []string{}
+	for i := 0; i < count; i++ {
+		id := fmt.Sprintf("%v-cid-%v", prefix, rand.Int63())
+		ids = append(ids, id)
+
+		key := cacher.allMessageCacheKey(id)
+		rdb.Set(context.Background(), key, "openim", 0)
+	}
+
+	// delete 100 keys with scan.
+	for i := 0; i < 100; i++ {
+		pickedKey := ids[i]
+		err := cacher.CleanUpOneConversationAllMsg(context.Background(), pickedKey)
+		assert.Nil(t, err)
+
+		ls, err := rdb.Keys(context.Background(), pickedKey).Result()
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(ls))
+
+		rcode, err := rdb.Exists(context.Background(), pickedKey).Result()
+		assert.Nil(t, err)
+		assert.EqualValues(t, 0, rcode) // non-exists
+	}
+
+	sid := fmt.Sprintf("%v-cid-*", prefix)
+	ls, err := rdb.Keys(context.Background(), cacher.allMessageCacheKey(sid)).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, count-100, len(ls))
+
+	// delete fuzzy matching keys.
+	err = cacher.CleanUpOneConversationAllMsg(context.Background(), sid)
+	assert.Nil(t, err)
+
+	// don't contains keys matched `{prefix}-cid-{random}` on redis
+	ls, err = rdb.Keys(context.Background(), cacher.allMessageCacheKey(sid)).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(ls))
+}


### PR DESCRIPTION
### summary

pervent redis block when use `keys *` command to request redis.

1. replace redis.keys to redis.scan.
2. the redis of many companies don't support the keys command, Or deny keys command.