### PR TITLE
fix: Bash Compatibility in print_services_and_ports Function

### DIFF
--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -31,15 +31,17 @@ OPENIM_VERBOSE=4
 openim::log::info "\n# Begin to check all openim service"
 
 # Elegant printing function
+# Elegant printing function
 print_services_and_ports() {
-    local -n service_names=$1
-    local -n service_ports=$2
+    local service_names=("$@")
+    local half_length=$((${#service_names[@]} / 2))
+    local service_ports=("${service_names[@]:half_length}")
 
     echo "+-------------------------+----------+"
     echo "| Service Name            | Port     |"
     echo "+-------------------------+----------+"
 
-    for index in "${!service_names[@]}"; do
+    for ((index=0; index < half_length; index++)); do
         printf "| %-23s | %-8s |\n" "${service_names[$index]}" "${service_ports[$index]}"
     done
 
@@ -50,11 +52,10 @@ print_services_and_ports() {
 # Similarly for OPENIM_DEPENDENCY_TARGETS and OPENIM_DEPENDENCY_PORT_TARGETS
 
 # Print out services and their ports
-print_services_and_ports OPENIM_SERVER_NAME_TARGETS OPENIM_SERVER_PORT_TARGETS
+print_services_and_ports "${OPENIM_SERVER_NAME_TARGETS[@]}" "${OPENIM_SERVER_PORT_TARGETS[@]}"
 
 # Print out dependencies and their ports
-print_services_and_ports OPENIM_DEPENDENCY_TARGETS OPENIM_DEPENDENCY_PORT_TARGETS
-
+print_services_and_ports "${OPENIM_DEPENDENCY_TARGETS[@]}" "${OPENIM_DEPENDENCY_PORT_TARGETS[@]}"
 
 # OpenIM check
 echo "++ The port being checked: ${OPENIM_SERVER_PORT_LISTARIES[@]}"


### PR DESCRIPTION
<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
#### 🔍 What type of PR is this?

<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

<!--Why do we need this PR?-->

This Pull Request addresses the compatibility issue in the print_services_and_ports function found in check-all.sh, enabling it to work with Bash versions older than 4.3. The solution involves removing the use of named references (local -n), which are not supported in older Bash versions.




#### 🅰 Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If there are multiple PRS, use `Resolves #10, resolves #123, resolves octo-org/octo-repo#100`
If there is a relevant PR, use `octo-org/octo-repo#123`
-->

Rewritten print_services_and_ports to accept arrays directly as arguments.
The function now handles service names and ports without relying on named references, ensuring compatibility with a broader range of Bash environments.

The modified script has been tested in environments with both older (pre-4.3) and newer versions of Bash.
All tests ensure that the function correctly prints services and their corresponding ports without errors.

Fixes #1642

#### 📝 Special notes for your reviewer:

<!-- What else would you tell someone who reviews your code -->

#### 🎯 Describe how to verify it

While this change aims at increasing compatibility, performance impacts (if any) on environments with large arrays should be minimal.
Further testing in varied environments is recommended to ensure consistent behavior.


<!-- Make sure to execute it `make all` locally, and it passed the test.-->

#### 📑 Additional documentation e.g., RFC, notion, Google docs, usage docs, etc.:


<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

In the sharers Guide, we recommend the following documents:
1. Using GitHub RFCs template: https://github.com/OpenIMSDK/community/blob/main/0000-template.md
2. Use Google Docs OR Notion and share it with the community.
-->
