### PR TITLE
fix: rIssue with Asset Uploading for Official Releases in GoReleaser Action v4 - release openim version not auto build 

### DIFF
--- a/build/goreleaser.yaml
+++ b/build/goreleaser.yaml
@@ -3,12 +3,36 @@
 
 before:
   hooks:
+    - make clean
     # You may remove this if you don't use go modules.
     - make tidy
     - make copyright.add
     # you may remove this if you don't need go generate
     - go generate ./...
 
+git:
+  # What should be used to sort tags when gathering the current and previous
+  # tags if there are more than one tag in the same commit.
+  #
+  # Default: '-version:refname'
+  tag_sort: -version:creatordate
+
+  # What should be used to specify prerelease suffix while sorting tags when gathering
+  # the current and previous tags if there are more than one tag in the same commit.
+  #
+  # Since: v1.17
+  prerelease_suffix: "-"
+
+  # Tags to be ignored by GoReleaser.
+  # This means that GoReleaser will not pick up tags that match any of the
+  # provided values as either previous or current tags.
+  #
+  # Templates: allowed.
+  # Since: v1.21.
+  ignore_tags:
+    - nightly
+    # - "{{.Env.IGNORE_TAG}}"
+  
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
I'm currently experiencing a problem with the GoReleaser Action v4 in our GitHub Actions workflow, specifically when releasing different types of versions. While pre-releases such as v3.5.1.beta.0 are being published successfully, the action encounters failures during the publishing of official releases (e.g., v3.5.1).

#### 🔍 What type of PR is this?

/kind documentation
/kind feature

<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

<!--Why do we need this PR?-->

The issue is evident in the 'release actions' job of our workflow. Detailed information and logs can be found here: [Release Actions Job](https://github.com/openimsdk/chat/actions/runs/7364259821/job/20044473138)


#### 🅰 Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If there are multiple PRS, use `Resolves #10, resolves #123, resolves octo-org/octo-repo#100`
If there is a relevant PR, use `octo-org/octo-repo#123`
-->

Fixes #

#### 📝 Special notes for your reviewer:

<!-- What else would you tell someone who reviews your code -->

#### 🎯 Describe how to verify it

<!-- Make sure to execute it `make all` locally, and it passed the test.-->

#### 📑 Additional documentation e.g., RFC, notion, Google docs, usage docs, etc.:


<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

In the sharers Guide, we recommend the following documents:
1. Using GitHub RFCs template: https://github.com/OpenIMSDK/community/blob/main/0000-template.md
2. Use Google Docs OR Notion and share it with the community.
-->
