### PR TITLE
docs:Add multi-language README.md in ./docs/ file

### DIFF
--- a/docs/README_ar.md
+++ b/docs/README_ar.md
@@ -1,0 +1,67 @@
+# وثائق OpenIM Server
+
+مرحبًا بكم في مركز وثائق OpenIM! يوفر هذا المركز مجموعة شاملة من الأدلة والكتيبات التي صُممت لمساعدتك في الاستفادة القصوى من تجربة OpenIM الخاصة بك.
+
+## جدول المحتويات
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - إرشادات حول المساهمة والتكوينات للمطورين
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - اتفاقيات الكود، سياسات التسجيل، وأدوات التحويل الأخرى
+
+------
+
+## مساهمة
+
+هذا القسم يقدم للمطورين دليلاً مفصلاً حول كيفية المساهمة في الكود، إعداد بيئتهم، واتباع العمليات المرتبطة.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - قواعد واتفاقيات لكتابة الكود في OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - دليل حول كيفية القيام بالتطوير داخل OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - إرشادات حول عمليات اختيار الجيت.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - سير عمل الجيت في OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - إرشادات حول إعداد وتهيئة OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - كيفية تثبيت الدوكر على جهازك.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - دليل لإعداد بيئة التطوير على لينكس.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - إرشادات حول كيفية القيام ببعض الأعمال الشائعة محليًا.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - طرق توظيف OpenIM دون اتصال.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - دليل حول استخدام أدوات بروتوك.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - أدوات ومكتبات في OpenIM للغة Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - أفضل الممارسات والأدوات لملفات الصيانة.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - أفضل الممارسات والأدوات للسكربتات.
+
+## التحويلات
+
+يقدم هذا القسم مختلف الاتفاقيات والسياسات داخل OpenIM، التي تشمل الكود، السجلات، الإصدارات، والمزيد.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - إرشادات وطرق لتحويلات API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - سياسات واتفاقيات التسجيل في OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - إجراءات واتفاقيات لـ CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - اتفاقيات لالتزامات الكود في OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - هيكل الدليل واتفاقياته داخل OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - قائمة وأوصاف رموز الخطأ.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - اتفاقيات وتحويلات لكود Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - استراتيجيات إدارة صور الدوكر في OpenIM، تشمل عدة معماريات ومستودعات الصور.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - اتفاقيات أكثر تفصيلاً حول التسجيل.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - استراتيجيات التسمية والإدارة لإصدارات OpenIM.
+
+
+## للمطورين والمساهمين ومشرفي المجتمع
+
+### المطورون والمساهمون
+
+إذا كنت مطورًا أو شخصًا حريصًا على المساهمة:
+
+- تعرف على [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) و[Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) لضمان سلاسة المساهمات.
+- اغمر نفسك في [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) للتعرف على ممارسات التطوير في OpenIM.
+
+### مشرفو المجتمع
+
+كمشرف على المجتمع:
+
+- تأكد من أن المساهمات تتوافق مع المعايير الموضحة في وثائقنا.
+- راجع بانتظام [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) و[Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) للبقاء على اطلاع.
+
+## للمستخدمين
+
+يجب أن يولي المستخدمون اهتمامًا خاصًا لـ:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - ضروري إذا كنت تخطط لاستخدام صور الدوكر لـ OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - لفهم الصور المختلفة المتاحة وكيفية اختيار ال

--- a/docs/README_cs.md
+++ b/docs/README_cs.md
@@ -1,0 +1,67 @@
+# Dokumenty serveru OpenIM
+
+Vítejte v centru dokumentace OpenIM! Toto centrum poskytuje komplexní řadu průvodců a manuálů navržených tak, aby vám pomohly co nejlépe využít vaše zkušenosti s OpenIM.
+
+## Obsah
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Pokyny pro přispívání a konfigurace pro vývojáře
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Konvence kódování, zásady protokolování a další transformační nástroje
+
+------
+
+## Contrib
+
+Tato část nabízí vývojářům podrobný návod, jak přispívat kódem, nastavovat prostředí a sledovat související procesy.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Pravidla a konvence pro psaní kódu v OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Návod, jak provádět vývoj v rámci OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Pokyny pro operace sběru třešní.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Pracovní postup git v OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Pokyny k nastavení a inicializaci OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Jak nainstalovat Docker na váš počítač.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Průvodce nastavením vývojového prostředí na Linuxu.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Pokyny k provádění určitých společných akcí na místní úrovni.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Metody nasazení OpenIM offline.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Průvodce používáním protokolových nástrojů.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Nástroje a knihovny v OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Osvědčené postupy a nástroje pro Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Doporučené postupy a nástroje pro skripty.
+
+## Konverze
+
+Tato část představuje různé konvence a zásady v rámci OpenIM, zahrnující kód, protokoly, verze a další.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Pokyny a metody pro konverze API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Zásady a konvence protokolování v OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Postupy a konvence pro CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Konvence pro odevzdání kódu v OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Struktura adresářů a konvence v rámci OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Seznam a popisy chybových kódů.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Konvence a převody pro kód Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Strategie správy pro obrazy OpenIM Docker, zahrnující různé architektury a úložiště obrazů.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Další podrobné konvence o protokolování.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Strategie pojmenování a správy verzí OpenIM.
+
+
+## Pro vývojáře, přispěvatele a správce komunity
+
+### Vývojáři a přispěvatelé
+
+Pokud jste vývojář nebo někdo, kdo má zájem přispívat:
+
+- Seznamte se s našimi [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) a [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md), abyste zajistili hladké příspěvky.
+- Ponořte se do [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md), abyste se seznámili s vývojovými postupy v OpenIM.
+
+### Správci komunity
+
+Jako správce komunity:
+
+- Zajistěte, aby příspěvky odpovídaly standardům uvedeným v naší dokumentaci.
+- Pravidelně kontrolujte [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) a [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) , abyste zůstali aktuální.
+
+## Pro uživatele
+
+Uživatelé by měli věnovat zvláštní pozornost:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Nezbytné, pokud plánujete používat obrazy OpenIM Docker.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Chcete-li porozumět různým dostupným obrázkům a jak vybrat ten správný pro vaši architekturu.

--- a/docs/README_da.md
+++ b/docs/README_da.md
@@ -1,0 +1,67 @@
+# OpenIM Server Dokumentation
+
+Velkommen til OpenIM Dokumentationscentret! Dette center indeholder en omfattende række vejledninger og manualer, der er designet til at hjælpe dig med at få mest muligt ud af din OpenIM-oplevelse.
+
+## Indholdsfortegnelse
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Vejledning om bidrag og konfigurationer for udviklere
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Kodningskonventioner, logningspolitikker og andre transformationsværktøjer
+
+------
+
+## Bidrag
+
+Denne sektion tilbyder udviklere en detaljeret vejledning om, hvordan de kan bidrage med kode, konfigurere deres miljø og følge de tilknyttede processer.
+
+- [Kodekonventioner](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Regler og konventioner for at skrive kode i OpenIM.
+- [Udviklingsguide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - En guide om, hvordan man udfører udvikling inden for OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Retningslinjer for cherry-picking-operationer.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Git-workflowen i OpenIM.
+- [Initialiseringskonfigurationer](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Vejledning om opsætning og initialisering af OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Sådan installeres Docker på din maskine.
+- [Linux Udviklingsmiljø](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Guide til opsætning af udviklingsmiljøet på Linux.
+- [Lokale handlinger](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Retningslinjer for, hvordan man udfører visse almindelige handlinger lokalt.
+- [Offline-deploering](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Metoder til at udrulle OpenIM offline.
+- [Protoc-værktøjer](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Guide til brug af protoc-værktøjer.
+- [Go-værktøjer](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Værktøjer og biblioteker i OpenIM til Go.
+- [Makefile-værktøjer](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Bedste praksis og værktøjer til Makefile.
+- [Scriptværktøjer](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Bedste praksis og værktøjer til scripts.
+
+## Konverteringer
+
+Denne sektion introducerer forskellige konventioner og politikker inden for OpenIM, herunder kode, logfiler, versioner og meget mere.
+
+- [API-konverteringer](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Retningslinjer og metoder til API-konverteringer.
+- [Logningspolitik](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Politikker og konventioner for logning i OpenIM.
+- [CI/CD-handlinger](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Procedurer og konventioner for CI/CD.
+- [Commit-konventioner](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Konventioner for kodeforpligtelser i OpenIM.
+- [Mappekonventioner](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Mappens struktur og konventioner inden for OpenIM.
+- [Fejlkoder](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Liste og beskrivelser af fejlkoder.
+- [Go-kodekonverteringer](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Konventioner og konverteringer for Go-kode.
+- [Docker Image-strategi](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Styringsstrategier for OpenIM Docker-billeder, der dækker flere arkitekturer og billedarkiver.
+- [Logningskonventioner](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Yderligere detaljerede konventioner om logning.
+- [Versionkonventioner](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Navngivnings- og styringsstrategier for OpenIM-versioner.
+
+
+## For udviklere, bidragsydere og samfundsvedligeholdere
+
+### Udviklere og bidragsydere
+
+Hvis du er en udvikler eller nogen, der gerne vil bidrage:
+
+- Gør dig fortrolig med vores [Kodekonventioner](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) og [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) for at sikre en problemfri bidragelse.
+- Dyk ned i [Udviklingsguiden](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) for at få en idé om udviklingspraksis i OpenIM.
+
+### Samfundsvedligeholdere
+
+Som samfundsvedligeholder:
+
+- Sørg for, at bidrag stemmer overens med standarderne beskrevet i vores dokumentation.
+- Gennemgå regelmæssigt [Logningspolitikken](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) og [Fejlkoderne](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) for at holde dig opdateret.
+
+## For brugere
+
+Brugere bør være opmærksomme på følgende:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Nødvendigt, hvis du planlægger at bruge Docker-billeder af OpenIM.
+- [Docker Image-strategi](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - For at forstå de forskellige tilgængelige billeder og hvordan man vælger det rigtige for din arkitektur.

--- a/docs/README_de.md
+++ b/docs/README_de.md
@@ -1,0 +1,66 @@
+# OpenIM-Serverdokumente
+
+Willkommen im OpenIM-Dokumentationshub! Dieses Zentrum bietet eine umfassende Auswahl an Leitfäden und Handbüchern, die Ihnen dabei helfen sollen, das Beste aus Ihrem OpenIM-Erlebnis herauszuholen.
+
+## Inhaltsverzeichnis
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Anleitung zu Beiträgen und Konfigurationen für Entwickler
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Codierungskonventionen, Protokollierungsrichtlinien und andere Transformationstools
+
+------
+
+## Beitrag
+
+Dieser Abschnitt bietet Entwicklern eine detaillierte Anleitung zum Beitragen von Code, zum Einrichten ihrer Umgebung und zum Befolgen der zugehörigen Prozesse.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Regeln und Konventionen zum Schreiben von Code in OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Eine Anleitung zur Durchführung der Entwicklung innerhalb von OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Richtlinien zur Rosinenpickerei.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Der Git-Workflow in OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Anleitung zum Einrichten und Initialisieren von OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - So installieren Sie Docker auf Ihrem Computer.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Anleitung zum Einrichten der Entwicklungsumgebung unter Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Richtlinien zur Durchführung bestimmter allgemeiner Aktionen vor Ort.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Methoden zur Offline-Bereitstellung von OpenIM.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Anleitung zur Verwendung von Protokolltools.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Tools und Bibliotheken in OpenIM für Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Best Practices und Tools für Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Best Practices und Tools für Skripte.
+
+## Konvertierungen
+
+In diesem Abschnitt werden verschiedene Konventionen und Richtlinien innerhalb von OpenIM vorgestellt, die Code, Protokolle, Versionen und mehr umfassen.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Richtlinien und Methoden für API-Konvertierungen.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Protokollierungsrichtlinien und -konventionen in OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Verfahren und Konventionen für CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Konventionen für Code-Commits in OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Verzeichnisstruktur und Konventionen innerhalb von OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Liste und Beschreibungen der Fehlercodes.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Konventionen und Konvertierungen für Go-Code.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Verwaltungsstrategien für OpenIM-Docker-Images, die mehrere Architekturen und Image-Repositorys umfassen.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Weitere detaillierte Konventionen zur Protokollierung.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Benennungs- und Verwaltungsstrategien für OpenIM-Versionen.
+
+
+## Für Entwickler, Mitwirkende und Community-Betreuer
+
+### Entwickler und Mitwirkende
+
+Wenn Sie Entwickler sind oder gerne einen Beitrag leisten möchten:
+- Machen Sie sich mit unseren [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) und unserem [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) vertraut, um reibungslose Beiträge zu gewährleisten.
+- Tauchen Sie ein in den [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md), um sich mit den Entwicklungspraktiken in OpenIM vertraut zu machen.
+
+### Community-Betreuer
+
+Als Community-Betreuer:
+
+- Stellen Sie sicher, dass die Beiträge den in unserer Dokumentation dargelegten Standards entsprechen.
+- Überprüfen Sie regelmäßig die [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) und die [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md), um auf dem Laufenden zu bleiben.
+
+## Für Benutzer
+
+Benutzer sollten besonders auf Folgendes achten:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Erforderlich, wenn Sie Docker-Images von OpenIM verwenden möchten.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Um die verschiedenen verfügbaren Bilder zu verstehen und wie Sie das richtige für Ihre Architektur auswählen.

--- a/docs/README_el.md
+++ b/docs/README_el.md
@@ -1,0 +1,67 @@
+# Έγγραφα διακομιστή OpenIM
+
+Καλώς ήρθατε στο κέντρο τεκμηρίωσης OpenIM! Αυτό το κέντρο παρέχει μια ολοκληρωμένη σειρά οδηγών και εγχειριδίων που έχουν σχεδιαστεί για να σας βοηθήσουν να αξιοποιήσετε στο έπακρο την εμπειρία σας στο OpenIM.
+
+## Πίνακας περιεχομένων
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Οδηγίες για τη συνεισφορά και τις διαμορφώσεις για προγραμματιστές
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Συμβάσεις κωδικοποίησης, πολιτικές καταγραφής και άλλα εργαλεία μετασχηματισμού
+
+------
+
+## Συνεισφορά
+
+Αυτή η ενότητα προσφέρει στους προγραμματιστές έναν λεπτομερή οδηγό για το πώς να συνεισφέρουν κώδικα, να ρυθμίσουν το περιβάλλον τους και να ακολουθήσουν τις σχετικές διαδικασίες.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Κανόνες και συμβάσεις για τη σύνταξη κώδικα στο OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Ένας οδηγός για το πώς να πραγματοποιήσετε ανάπτυξη στο OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Οδηγίες για τις εργασίες συλλογής κερασιών.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Η ροή εργασίας git στο OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Οδηγίες για τη ρύθμιση και την προετοιμασία του OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Πώς να εγκαταστήσετε το Docker στο μηχάνημά σας.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Οδηγός για τη ρύθμιση του περιβάλλοντος ανάπτυξης στο Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Οδηγίες για τον τρόπο εκτέλεσης ορισμένων κοινών ενεργειών σε τοπικό επίπεδο.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Μέθοδοι ανάπτυξης OpenIM εκτός σύνδεσης.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Οδηγός χρήσης εργαλείων πρωτοκόλλου.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Εργαλεία και βιβλιοθήκες στο OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Βέλτιστες πρακτικές και εργαλεία για το Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Βέλτιστες πρακτικές και εργαλεία για σενάρια.
+
+## Μετατροπές
+
+Αυτή η ενότητα εισάγει διάφορες συμβάσεις και πολιτικές στο OpenIM, που περιλαμβάνουν κώδικα, αρχεία καταγραφής, εκδόσεις και άλλα.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Οδηγίες και μέθοδοι για μετατροπές API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Πολιτικές και συμβάσεις καταγραφής στο OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Διαδικασίες και συμβάσεις για CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Συμβάσεις για δεσμεύσεις κώδικα στο OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Δομή καταλόγου και συμβάσεις στο OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Λίστα και περιγραφές κωδικών σφαλμάτων.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Συμβάσεις και μετατροπές για τον κώδικα Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Στρατηγικές διαχείρισης για εικόνες OpenIM Docker, που εκτείνονται σε πολλαπλές αρχιτεκτονικές και αποθετήρια εικόνων.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Περαιτέρω λεπτομερείς συμβάσεις για την υλοτομία.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Στρατηγικές ονομασίας και διαχείρισης για εκδόσεις OpenIM.
+
+
+## Για προγραμματιστές, συνεισφέροντες και συντηρητές κοινότητας
+
+### Προγραμματιστές & Συνεισφέροντες
+
+Εάν είστε προγραμματιστής ή κάποιος που επιθυμεί να συνεισφέρει:
+
+- Εξοικειωθείτε με τις [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) και [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) για να εξασφαλίσετε ομαλή συνεισφορά.
+- Βουτήξτε στον [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) για να δείτε τις πρακτικές ανάπτυξης στο OpenIM.
+
+### Συντηρητές της Κοινότητας
+
+Ως συντηρητής κοινότητας:
+
+- Βεβαιωθείτε ότι οι συνεισφορές ευθυγραμμίζονται με τα πρότυπα που περιγράφονται στην τεκμηρίωσή μας.
+- Να ελέγχετε τακτικά την [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) και τους [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) για να ενημερώνεστε.
+
+## Για Χρήστες
+
+Οι χρήστες θα πρέπει να δώσουν ιδιαίτερη προσοχή:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Απαραίτητο εάν σκοπεύετε να χρησιμοποιήσετε εικόνες Docker του OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Για να κατανοήσετε τις διάφορες διαθέσιμες εικόνες και πώς να επιλέξετε τη σωστή για την αρχιτεκτονική σας.

--- a/docs/README_eo.md
+++ b/docs/README_eo.md
@@ -1,0 +1,67 @@
+# OpenIM Server Docs
+
+Bonvenon al la OpenIM Dokumenta nabo! Ĉi tiu centro disponigas ampleksan gamon da gvidiloj kaj manlibroj desegnitaj por helpi vin eltiri la plej grandan parton de via OpenIM-sperto.
+
+## Enhavtabelo
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Gvidilo pri kontribuado kaj agordoj por programistoj
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Kodigaj konvencioj, registradaj politikoj kaj aliaj transformaj iloj
+
+------
+
+## Kontribui
+
+Ĉi tiu sekcio ofertas al programistoj detalan gvidilon pri kiel kontribui kodon, agordi sian medion kaj sekvi la rilatajn procezojn.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Reguloj kaj konvencioj por skribi kodon en OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Gvidilo pri kiel efektivigi disvolviĝon ene de OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Gvidlinioj pri ĉeriz-plukaj operacioj.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - La git-laborfluo en OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Gvidilo pri agordo kaj pravalorigo de OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Kiel instali Docker sur via maŝino.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Gvidilo por agordi la evolumedion en Linukso.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Gvidlinioj pri kiel efektivigi certajn komunajn agojn loke.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Metodoj por disfaldi OpenIM eksterrete.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Gvidilo pri uzado de protokaj iloj.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Iloj kaj bibliotekoj en OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Plej bonaj praktikoj kaj iloj por Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Plej bonaj praktikoj kaj iloj por skriptoj.
+
+## Konvertiĝoj
+
+Ĉi tiu sekcio enkondukas diversajn konvenciojn kaj politikojn ene de OpenIM, ampleksante kodon, protokolojn, versiojn kaj pli.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Gvidlinioj kaj metodoj por API-konvertoj.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Registrado de politikoj kaj konvencioj en OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Proceduroj kaj konvencioj por CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Konvencioj por kodoj en OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Dosierujo-strukturo kaj konvencioj ene de OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Listo kaj priskriboj de erarkodoj.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Konvencioj kaj konvertiĝoj por Go-kodo.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Administradstrategioj por OpenIM Docker-bildoj, ampleksante plurajn arkitekturojn kaj bilddeponejojn.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Pliaj detalaj konvencioj pri arbohakado.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Strategioj pri nomado kaj administrado por OpenIM-versioj.
+
+
+## Por Programistoj, Kontribuantoj kaj Komunumaj Prizorgantoj
+
+### Programistoj kaj Kontribuantoj
+
+Se vi estas programisto aŭ iu fervora kontribui:
+
+- Familiariĝu kun niaj [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) por certigi glatajn kontribuojn.
+- Plonĝu en la[Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) por ekkompreni la evolupraktikojn en OpenIM.
+
+### Komunumaj Prizorgantoj
+
+Kiel komunuma prizorganto:
+
+- Certigu, ke kontribuoj kongruas kun la normoj skizitaj en nia dokumentaro.
+- Regule reviziu la [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) kaj [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) por resti ĝisdatigita.
+
+## Por Uzantoj
+
+Uzantoj devas aparte atenti:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Necesas se vi planas uzi Docker-bildojn de OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Por kompreni la malsamajn bildojn disponeblajn kaj kiel elekti la ĝustan por via arkitekturo.

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -1,0 +1,67 @@
+# Documentos del servidor OpenIM
+
+¡Bienvenido al centro de documentación de OpenIM! Este centro proporciona una amplia gama de guías y manuales diseñados para ayudarle a aprovechar al máximo su experiencia OpenIM.
+
+## Tabla de contenido
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Orientación sobre contribuciones y configuraciones para desarrolladores
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Convenciones de codificación, políticas de registro y otras herramientas de transformación
+
+------
+
+## Contribuir
+
+Esta sección ofrece a los desarrolladores una guía detallada sobre cómo contribuir con código, configurar su entorno y seguir los procesos asociados.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Reglas y convenciones para escribir código en OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Una guía sobre cómo realizar el desarrollo dentro de OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Directrices sobre operaciones de selección selectiva.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - El flujo de trabajo de git en OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Orientación sobre la configuración e inicialización de OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Cómo instalar Docker en su máquina.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Guía para configurar el entorno de desarrollo en Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Lineamientos sobre cómo llevar a cabo determinadas acciones comunes a nivel local.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Métodos de implementación de OpenIM sin conexión.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Guía sobre el uso de herramientas de protocolo.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Herramientas y bibliotecas en OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Mejores prácticas y herramientas para Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Mejores prácticas y herramientas para scripts.
+
+## Conversiones
+
+Esta sección presenta varias convenciones y políticas dentro de OpenIM, que abarcan código, registros, versiones y más.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Directrices y métodos para conversiones de API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Políticas y convenciones de registro en OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Procedimientos y convenciones para CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Convenciones para confirmaciones de código en OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Estructura de directorios y convenciones dentro de OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Lista y descripciones de códigos de error.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Convenciones y conversiones para código Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Estrategias de gestión para imágenes OpenIM Docker, que abarcan múltiples arquitecturas y repositorios de imágenes.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Convenciones más detalladas sobre el registro.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Estrategias de nomenclatura y gestión de versiones OpenIM.
+
+
+## Para desarrolladores, contribuyentes y mantenedores de la comunidad
+
+### Desarrolladores y colaboradores
+
+Si eres desarrollador o alguien interesado en contribuir:
+
+- Familiarícese con nuestras [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) y [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) to ensure smooth contributions.
+- Sumérgete en la [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) para familiarizarte con las prácticas de desarrollo en OpenIM.
+
+### Mantenedores de la comunidad
+
+Como mantenedor de la comunidad:
+
+- Asegúrese de que las contribuciones se alineen con los estándares descritos en nuestra documentación.
+- Revise periódicamente la [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) y los [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) para mantenerse actualizado.
+
+## Para usuarios
+
+Los usuarios deben prestar especial atención a:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Necesario si planea utilizar imágenes Docker de OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Comprender las diferentes imágenes disponibles y cómo elegir la adecuada para su arquitectura.

--- a/docs/README_fa.md
+++ b/docs/README_fa.md
@@ -1,0 +1,67 @@
+# اسناد سرور OpenIM
+
+به مرکز اسناد OpenIM خوش آمدید! این مرکز طیف گسترده ای از راهنماها و راهنماها را ارائه می دهد که به شما کمک می کند تا از تجربه OpenIM خود بیشترین بهره را ببرید.
+
+## فهرست مطالب
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - راهنمایی در مورد مشارکت و تنظیمات برای توسعه دهندگان
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - کنوانسیون های کدگذاری، سیاست های ورود به سیستم و سایر ابزارهای تبدیل
+
+------
+
+## مشارکت
+
+این بخش به توسعه دهندگان راهنمای دقیقی در مورد نحوه مشارکت کد، تنظیم محیط خود و پیروی از فرآیندهای مرتبط ارائه می دهد.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - قوانین و مقررات برای نوشتن کد در OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - راهنمای نحوه انجام توسعه در OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - دستورالعمل عملیات چیدن گیلاس
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - گردش کار git در OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - راهنمایی در مورد راه اندازی و مقداردهی اولیه OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - چگونه داکر را روی دستگاه خود نصب کنیم.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - راهنمای راه اندازی محیط توسعه در لینوکس.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - رهنمودهایی در مورد نحوه انجام برخی از اقدامات مشترک به صورت محلی.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - روش های استقرار OpenIM به صورت آفلاین
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - راهنمای استفاده از ابزار پروتک
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - ابزارها و کتابخانه ها در OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - بهترین روش ها و ابزارها برای Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - بهترین روش ها و ابزارها برای اسکریپت ها.
+
+## تبدیل ها
+
+این بخش قراردادها و سیاست‌های مختلفی را در OpenIM معرفی می‌کند که شامل کد، گزارش‌ها، نسخه‌ها و موارد دیگر می‌شود.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - دستورالعمل ها و روش های تبدیل API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - سیاست‌های ورود به سیستم و قراردادها در OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - رویه ها و قراردادها برای CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - کنوانسیون‌ها برای تعهدات کد در OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - ساختار دایرکتوری و قراردادها در OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - لیست و توضیحات کدهای خطا
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - کنوانسیون ها و تبدیل ها برای کد Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - استراتژی های مدیریتی برای تصاویر OpenIM Docker، شامل چندین معماری و مخازن تصویر.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - کنوانسیون های دقیق تر در مورد ورود به سیستم.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - استراتژی های نامگذاری و مدیریت برای نسخه های OpenIM.
+
+
+## برای توسعه‌دهندگان، مشارکت‌کنندگان و نگهبانان انجمن
+
+### توسعه دهندگان و مشارکت کنندگان
+
+اگر توسعه‌دهنده هستید یا کسی که مشتاق مشارکت است:
+
+- - برای اطمینان از مشارکت های روان، با [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) و [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) ما آشنا شوید.
+- - در [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) شیرجه بزنید تا از شیوه های توسعه در OpenIM مطلع شوید.
+
+### نگهبانان جامعه
+
+به عنوان یک نگهدارنده جامعه:
+
+- اطمینان حاصل کنید که مشارکت ها با استانداردهای ذکر شده در اسناد ما مطابقت دارند.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) و [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) را به‌طور مرتب مرور کنید تا به‌روز بمانید.
+
+## برای کاربران
+
+کاربران باید توجه ویژه ای به موارد زیر داشته باشند:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - اگر قصد دارید از تصاویر Docker OpenIM استفاده کنید، ضروری است.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - برای درک تصاویر مختلف موجود و نحوه انتخاب تصویر مناسب برای معماری خود.

--- a/docs/README_fi.md
+++ b/docs/README_fi.md
@@ -1,0 +1,67 @@
+# OpenIM Server Docs
+
+Tervetuloa OpenIM-dokumentaatiokeskukseen! Tämä keskus tarjoaa kattavan valikoiman oppaita ja oppaita, jotka on suunniteltu auttamaan sinua saamaan kaiken irti OpenIM-kokemuksestasi.
+
+## Sisällysluettelo
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Ohjeita kehittäjille osallistumiseen ja määrityksiin
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Koodauskäytännöt, lokikäytännöt ja muut muunnostyökalut
+
+------
+
+## Contrib
+
+Tämä osio tarjoaa kehittäjille yksityiskohtaisen oppaan koodin lisäämisestä, ympäristön määrittämisestä ja siihen liittyvien prosessien seuraamisesta.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Säännöt ja käytännöt koodin kirjoittamiselle OpenIM:ssä.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Opas kehitystyön toteuttamiseen OpenIM:ssä.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Kirsikoiden poimimista koskevat ohjeet.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Git-työnkulku OpenIM:ssä.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Ohjeita OpenIM:n käyttöönottoon ja alustamiseen.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Kuinka asentaa Docker koneellesi.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Ohje kehitysympäristön määrittämiseen Linuxissa.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Ohjeita tiettyjen yhteisten toimien toteuttamiseen paikallisesti.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - OpenIM:n offline-käyttöönottomenetelmät.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Opas protokollatyökalujen käyttöön.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - OpenIM for Go -työkalut ja kirjastot.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Makefilen parhaat käytännöt ja työkalut.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Skriptien parhaat käytännöt ja työkalut.
+
+## Tulokset
+
+Tässä osiossa esitellään erilaisia OpenIM:n käytäntöjä ja käytäntöjä, jotka kattavat koodin, lokit, versiot ja paljon muuta.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Ohjeita ja menetelmiä API-muunnoksille.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Kirjauskäytännöt ja käytännöt OpenIM:ssä.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CD:n menettelyt ja käytännöt.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - OpenIM:n koodisitoumusten käytännöt.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Hakemistorakenne ja käytännöt OpenIM:ssä.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Luettelo ja kuvaukset virhekoodeista.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Go-koodin sopimukset ja muunnokset.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Hallintastrategiat OpenIM Docker -kuville, jotka kattavat useita arkkitehtuureja ja kuvavarastoja.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Tarkemmat hakkuiden käytännöt.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Nimeämis- ja hallintastrategiat OpenIM-versioille.
+
+
+## Kehittäjille, avustajille ja yhteisön ylläpitäjille
+
+### Kehittäjät ja avustajat
+
+Jos olet kehittäjä tai joku, joka haluaa osallistua:
+
+- Tutustu [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md)- ja [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) -käytäntöihimme varmistaaksesi sujuvan osallistumisen.
+- Sukella [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) saadaksesi tietoa OpenIM:n kehityskäytännöistä.
+
+### Yhteisön ylläpitäjät
+
+Yhteisön ylläpitäjänä:
+
+- Varmista, että osallistumiset ovat asiakirjoissamme esitettyjen standardien mukaisia.
+- Tarkista säännöllisesti [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) ja [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) pysyäksesi ajan tasalla.
+
+## Käyttäjille
+
+Käyttäjien tulee kiinnittää erityistä huomiota:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Välttämätön, jos aiot käyttää OpenIM:n Docker-kuvia.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Ymmärtääksesi saatavilla olevat erilaiset kuvat ja kuinka valita oikea arkkitehtuuriisi.

--- a/docs/README_fr.md
+++ b/docs/README_fr.md
@@ -1,0 +1,66 @@
+# Documentation du serveur OpenIM
+
+Bienvenue dans le hub de documentation OpenIM ! Ce centre propose une gamme complète de guides et de manuels conçus pour vous aider à tirer le meilleur parti de votre expérience OpenIM.
+
+## Table des matières
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Conseils sur la contribution et les configurations pour les développeurs
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Conventions de codage, politiques de journalisation et autres outils de transformation
+
+------
+
+## Contribuer
+
+Cette section propose aux développeurs un guide détaillé sur la façon de contribuer au code, de configurer leur environnement et de suivre les processus associés.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Règles et conventions pour écrire du code dans OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Un guide sur la façon de réaliser du développement au sein d'OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Lignes directrices sur les opérations de triage.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Le flux de travail git dans OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Conseils sur la configuration et l’initialisation d’OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Comment installer Docker sur votre machine.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Guide pour configurer l'environnement de développement sous Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Des lignes directrices pour mener localement certaines actions communes.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Méthodes de déploiement d'OpenIM hors ligne.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Guide sur l'utilisation des outils de protocole.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Outils et bibliothèques dans OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Meilleures pratiques et outils pour Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Meilleures pratiques et outils pour les scripts.
+
+## Conversions
+
+Cette section présente diverses conventions et politiques au sein d'OpenIM, englobant le code, les journaux, les versions, etc.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Lignes directrices et méthodes pour les conversions API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Politiques et conventions de journalisation dans OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Politiques et conventions de journalisation dans OpenIM.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Politiques et conventions de journalisation dans OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Structure de répertoire et conventions au sein d'OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Liste et descriptions des codes d'erreur.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Conventions et conversions pour le code Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Stratégies de gestion des images OpenIM Docker, couvrant plusieurs architectures et référentiels d'images.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Conventions plus détaillées sur la journalisation.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Stratégies de nommage et de gestion pour les versions OpenIM.
+
+
+## Pour les développeurs, les contributeurs et les responsables de la communauté
+
+### Développeurs et contributeurs
+
+Si vous êtes un développeur ou quelqu'un désireux de contribuer :
+- Familiarisez-vous avec nos [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) et notre [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) pour garantir des contributions fluides.
+- Plongez dans le [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) pour vous familiariser avec les pratiques de développement dans OpenIM.
+
+### Responsables de la communauté
+
+En tant que responsable de la communauté :
+
+- EAssurez-vous que les contributions sont conformes aux normes décrites dans notre documentation.
+- onsultez régulièrement la [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) et les [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) pour rester à jour.
+
+## Pour les utilisateurs
+
+Les utilisateurs doivent prêter une attention particulière à :
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Nécessaire si vous prévoyez d'utiliser des images Docker d'OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Pour comprendre les différentes images disponibles et comment choisir celle qui convient à votre architecture.

--- a/docs/README_hu.md
+++ b/docs/README_hu.md
@@ -1,0 +1,67 @@
+# OpenIM Server Docs
+
+Üdvözöljük az OpenIM dokumentációs központjában! Ez a központ útmutatók és kézikönyvek átfogó választékát kínálja, amelyek célja, hogy a legtöbbet hozza ki az OpenIM-élményből.
+
+## Tartalomjegyzék
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Útmutató a fejlesztőknek a hozzájáruláshoz és a konfigurációkhoz
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Kódolási konvenciók, naplózási szabályzatok és egyéb átalakítási eszközök
+
+------
+
+## Contrib
+
+Ez a rész részletes útmutatót nyújt a fejlesztőknek a kód hozzáadásával, a környezet beállításával és a kapcsolódó folyamatok követésével kapcsolatban.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Az OpenIM kódírásának szabályai és konvenciói.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Útmutató az OpenIM-en belüli fejlesztés végrehajtásához.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Útmutató a cseresznyeszedési műveletekhez.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - A git munkafolyamat az OpenIM-ben.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Útmutató az OpenIM beállításához és inicializálásához.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - A Docker telepítése a gépére.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Guide to set up the development environment on Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Útmutató a fejlesztői környezet beállításához Linuxon.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Az OpenIM offline üzembe helyezésének módszerei.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Útmutató a protokolleszközök használatához.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Eszközök és könyvtárak az OpenIM for Go-ban.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - A Makefile legjobb gyakorlatai és eszközei.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Bevált módszerek és eszközök a szkriptekhez.
+
+## Conversions
+
+Ez a rész az OpenIM különféle konvencióit és szabályzatait mutatja be, beleértve a kódot, a naplókat, a verziókat és egyebeket.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Irányelvek és módszerek az API-konverziókhoz.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Naplózási szabályzatok és konvenciók az OpenIM-ben.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CD eljárások és konvenciók.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - A kód véglegesítésének konvenciói az OpenIM-ben.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Címtárszerkezet és konvenciók az OpenIM-en belül.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - A hibakódok listája és leírása.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Konvenciók és átalakítások a Go kódhoz.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Kezelési stratégiák az OpenIM Docker-képekhez, amelyek több architektúrára és képtárra is kiterjednek.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - További részletes egyezmények a fakitermelésről.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Elnevezési és kezelési stratégiák az OpenIM verziókhoz.
+
+
+## Fejlesztőknek, közreműködőknek és közösségi fenntartóknak
+
+### Fejlesztők és közreműködők
+
+Ha Ön fejlesztő vagy valaki, aki szeretne hozzájárulni:
+
+- A zökkenőmentes hozzájárulás érdekében ismerkedjen meg [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) és [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md)-val.
+- Merüljön el a [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md), hogy megismerje az OpenIM fejlesztési gyakorlatát.
+
+### Közösségfenntartók
+
+Közösségfenntartóként:
+
+- Győződjön meg arról, hogy a hozzájárulások megfelelnek a dokumentációnkban felvázolt szabványoknak.
+- Rendszeresen tekintse át a [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) és a [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md), hogy naprakész maradjon.
+
+## Felhasználóknak
+
+A felhasználóknak különös figyelmet kell fordítaniuk a következőkre:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Szükséges, ha az OpenIM Docker-képeit szeretné használni.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Hogy megértse a rendelkezésre álló különböző képeket, és hogyan válassza ki a megfelelőt az építészetéhez.

--- a/docs/README_id.md
+++ b/docs/README_id.md
@@ -1,0 +1,67 @@
+# Dokumen Server OpenIM
+
+Selamat datang di pusat Dokumentasi OpenIM! Pusat ini menyediakan berbagai panduan dan manual yang komprehensif untuk membantu Anda memaksimalkan pengalaman Anda dengan OpenIM.
+
+## Daftar Isi
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Panduan tentang kontribusi dan konfigurasi untuk pengembang
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Konvensi pengkodean, kebijakan logging, dan alat transformasi lainnya
+
+------
+
+## Contrib
+
+Bagian ini menawarkan panduan rinci bagi pengembang tentang cara berkontribusi kode, menyiapkan lingkungan mereka, dan mengikuti proses yang terkait.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Aturan dan konvensi untuk menulis kode di OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Panduan tentang cara melakukan pengembangan di dalam OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Pedoman tentang operasi cherry-picking.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Alur kerja git di OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Panduan untuk mengatur dan menginisialisasi OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Cara memasang Docker di mesin Anda.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Panduan untuk menyiapkan lingkungan pengembangan di Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Pedoman tentang cara melakukan beberapa tindakan umum secara lokal.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Metode penyebaran OpenIM secara offline.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Panduan tentang menggunakan alat protoc.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Alat dan perpustakaan di OpenIM untuk Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Praktik terbaik dan alat untuk Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Praktik terbaik dan alat untuk skrip.
+
+## Conversions
+
+Bagian ini memperkenalkan berbagai konvensi dan kebijakan dalam OpenIM, meliputi kode, log, versi, dan lainnya.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Pedoman dan metode untuk konversi API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Kebijakan dan konvensi logging di OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Prosedur dan konvensi untuk CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Konvensi untuk commit kode di OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Struktur direktori dan konvensi dalam OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Daftar dan deskripsi kode kesalahan.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Konvensi dan konversi untuk kode Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Strategi manajemen gambar Docker OpenIM, mencakup berbagai arsitektur dan repositori gambar.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Konvensi logging yang lebih detail.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Strategi penamaan dan manajemen versi OpenIM.
+
+
+## Untuk Pengembang, Kontributor, dan Pemelihara Komunitas
+
+### Pengembang & Kontributor
+
+Jika Anda seorang pengembang atau seseorang yang ingin berkontribusi:
+
+- Kenali [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) dan [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) kami untuk memastikan kontribusi yang lancar.
+- Pelajari [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) untuk memahami praktik pengembangan di OpenIM.
+
+### Pemelihara Komunitas
+
+Sebagai pemelihara komunitas:
+
+- Pastikan kontribusi sesuai dengan standar yang diuraikan dalam dokumentasi kami.
+- Tinjau secara teratur [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) dan [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) untuk tetap terupdate.
+
+## Untuk Pengguna
+
+Pengguna harus memberikan perhatian khusus kepada:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Diperlukan jika Anda berencana menggunakan gambar Docker dari OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Untuk memahami gambar yang tersedia dan bagaimana memilih yang tepat untuk arsitektur Anda.

--- a/docs/README_it.md
+++ b/docs/README_it.md
@@ -1,0 +1,67 @@
+# Documentazione del Server OpenIM
+
+Benvenuti al centro documentazione di OpenIM! Questo centro offre una gamma completa di guide e manuali progettati per aiutarvi a ottenere il massimo dalla vostra esperienza con OpenIM.
+
+## Indice dei Contenuti
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Guida al contributo e alle configurazioni per gli sviluppatori
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Convenzioni di codifica, politiche di registrazione e altri strumenti di trasformazione
+
+------
+
+## Contrib
+
+Questa sezione offre agli sviluppatori una guida dettagliata su come contribuire al codice, configurare il loro ambiente e seguire i processi associati.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Regole e convenzioni per scrivere codice in OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Una guida su come svolgere lo sviluppo all'interno di OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Linee guida sulle operazioni di cherry-picking.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Il flusso di lavoro git in OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Guida per configurare e inizializzare OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Come installare Docker sul tuo dispositivo.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Guida per configurare l'ambiente di sviluppo su Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Linee guida su come eseguire determinate azioni comuni localmente.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Metodi per distribuire OpenIM offline.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Guida all'uso degli strumenti protoc.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Strumenti e librerie in OpenIM per Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Migliori pratiche e strumenti per Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Migliori pratiche e strumenti per gli script.
+
+## Conversions
+
+Questa sezione introduce varie convenzioni e politiche all'interno di OpenIM, che comprendono codice, registrazioni, versioni e altro.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Linee guida e metodi per le conversioni API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Politiche e convenzioni di registrazione in OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Procedure e convenzioni per CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Convenzioni per i commit di codice in OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Struttura delle directory e convenzioni all'interno di OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Elenco e descrizioni dei codici di errore.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Convenzioni e conversioni per il codice Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Strategie di gestione delle immagini Docker di OpenIM, che coprono più architetture e repository di immagini.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Ulteriori dettagliate convenzioni sulla registrazione.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Strategie di denominazione e gestione delle versioni di OpenIM.
+
+
+## Per Sviluppatori, Contributori e Manutentori della Comunità
+
+### Sviluppatori & Contributori
+
+Se sei uno sviluppatore o qualcuno interessato a contribuire:
+
+- Familiarizza con le nostre [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) e [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) per garantire contributi fluidi.
+- Approfondisci la [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) per ottenere una conoscenza delle pratiche di sviluppo in OpenIM.
+
+### Manutentori della Comunità
+
+Come manutentore della comunità:
+
+- Assicurati che i contributi siano in linea con gli standard delineati nella nostra documentazione.
+- Rivedi regolarmente la [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) e [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) per rimanere aggiornato.
+
+## Per gli Utenti
+
+Gli utenti dovrebbero prestare particolare attenzione a:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Necessario se si prevede di utilizzare le immagini Docker di OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Per comprendere le diverse immagini disponibili e come scegliere quella giusta per la propria architettura.

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -1,0 +1,67 @@
+# OpenIMサーバードキュメンテーション
+
+OpenIMドキュメンテーションハブへようこそ！このセンターでは、OpenIM体験を最大限に活用するための包括的なガイドとマニュアルを提供しています。
+
+## 目次
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - 開発者向けの貢献と設定に関するガイダンス
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - コーディング規約、ログポリシー、その他の変換ツール
+
+------
+
+## 投稿
+
+このセクションでは、開発者がコードを貢献し、環境を設定し、関連するプロセスに従う方法についての詳細なガイドを提供します。
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - OpenIMでのコード記述のルールと規約。
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - OpenIM内での開発を行うためのガイド。
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - チェリーピッキング操作のガイドライン。
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - OpenIMにおけるGitのワークフロー。
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - OpenIMの設定と初期化に関するガイダンス。
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - マシンにDockerをインストールする方法。
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Linux上での開発環境の設定ガイド。
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - ローカルで一般的なアクションを実行する方法に関するガイドライン。
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - OpenIMをオフラインでデプロイする方法。
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - protocツールの使用ガイド。
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - GoのためのOpenIM内のツールとライブラリ。
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Makefileのベストプラクティスとツール。
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - スクリプトのベストプラクティスとツール。
+
+## Conversions
+
+このセクションでは、OpenIM内のさまざまな規約とポリシーを紹介します。これには、コード、ログ、バージョンなどが含まれます。
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - API変換のためのガイドラインと方法。
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - OpenIMにおけるログポリシーと規約。
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CDの手順と規約。
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - OpenIMでのコードコミットのための規約。
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - OpenIM内のディレクトリ構造と規約。
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - エラーコードのリストと説明。
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Goコードのための規約と変換。
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - 複数のアーキテクチャとイメージリポジトリにまたがるOpenIM Dockerイメージの管理戦略。
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - ロギングに関するさらに詳細な規約。
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - OpenIMバージョンの命名と管理戦略。
+
+
+## 開発者、コントリビューター、コミュニティメンテナー向け
+
+### 開発者およびコントリビューター
+
+開発者または貢献に熱心な方へ：
+
+- スムーズな貢献を確実にするために、私たちの[Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md)と[Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md)に慣れ親しみましょう。
+- OpenIMの開発実践に慣れるために、[Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md)をご覧ください。
+
+### コミュニティメンテナー
+
+コミュニティメンテナーとして：
+
+- 貢献が私たちのドキュメンテーションで概説された基準に沿っていることを確認してください。
+- 最新の情報を得るために、定期的に[Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md)と[Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md)をレビューしてください。
+
+## ユーザー向け
+
+ユーザーは特に以下の点に注意してください：
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - OpenIMのDockerイメージを使用する予定の場合に必要です。
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - 利用可能なさまざまなイメージを理解し、アーキテクチャに適したものを選択する方法。

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -1,0 +1,67 @@
+# OpenIM 서버 문서
+
+OpenIM 문서 허브에 오신 것을 환영합니다! 이 센터는 OpenIM 경험을 최대한 활용하는 데 도움이 되도록 다양한 가이드와 매뉴얼을 제공합니다.
+
+## 목차
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - 개발자를 위한 기여 및 구성에 대한 안내
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - 코딩 규칙, 로깅 정책 및 기타 변환 도구
+
+------
+
+## 기여
+
+이 섹션은 개발자들에게 코드를 기여하는 방법, 환경을 설정하는 방법 및 관련 프로세스를 따르는 방법에 대한 자세한 가이드를 제공합니다.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - OpenIM에서 코드를 작성하기 위한 규칙 및 규약.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - OpenIM 내에서 개발을 수행하는 방법에 대한 가이드.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - 체리피킹 작업에 대한 지침.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - OpenIM에서의 깃 워크플로우.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - OpenIM 설정 및 초기화에 대한 안내.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - 컴퓨터에 도커를 설치하는 방법.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - 리눅스에서 개발 환경을 설정하는 가이드.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - 일부 일반적인 작업을 로컬에서 수행하는 방법에 대한 지침.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - 오프라인에서 OpenIM을 배포하는 방법.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - 프로토콜 도구 사용에 대한 가이드.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Go용 OpenIM 도구 및 라이브러리.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - 메이크파일을 위한 모범 사례 및 도구.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - 스크립트를 위한 모범 사례 및 도구.
+
+## 전환
+
+이 섹션에서는 코드, 로그, 버전 등을 포함하는 OpenIM 내의 다양한 규칙과 정책을 소개합니다.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - API 변환을 위한 지침 및 방법.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - OpenIM의 로깅 정책 및 관습.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CD 절차 및 관습.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - OpenIM에서 코드 커밋을 위한 관습.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - OpenIM 내의 디렉토리 구조 및 관습.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - 오류 코드 목록 및 설명.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Go 코드를 위한 관습 및 변환.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - 다양한 아키텍처 및 이미지 저장소를 아우르는 OpenIM Docker 이미지 관리 전략.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - 로깅에 대한 추가적인 상세한 관습.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - OpenIM 버전의 명명 및 관리 전략.
+
+
+## 개발자, 기여자 및 커뮤니티 관리자를 위한 정보
+
+### 개발자 및 기여자
+
+개발자이거나 기여에 관심이 있다면:
+
+- 원활한 기여를 위해 [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) 및 [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md)에 익숙해지십시오.
+- OpenIM에서의 개발 관행을 파악하려면 [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md)를 참조하십시오.
+
+### 커뮤니티 관리자
+
+커뮤니티 관리자로서:
+
+- 기여가 우리 문서에 명시된 표준에 부합하는지 확인하십시오.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) 및 [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md)를 정기적으로 검토하여 최신 정보를 유지하십시오.
+
+## 사용자를 위한 정보
+
+사용자는 특히 다음 사항에 주의를 기울여야 합니다:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - OpenIM의 Docker 이미지를 사용할 계획이라면 필요합니다.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - 사용 가능한 다양한 이미지를 이해하고 아키텍처에 적합한 이미지를 선택하는 방법.

--- a/docs/README_ml.md
+++ b/docs/README_ml.md
@@ -1,0 +1,67 @@
+# OpenIM സെർവർ ഡോക്യുമെന്റേഷൻ
+
+OpenIM ഡോക്യുമെന്റേഷൻ ഹബ്ബിലേക്ക് സ്വാഗതം! ഈ കേന്ദ്രം OpenIM അനുഭവത്തിൽ നിന്ന് പരമാവധി ഉപയോഗം നേടാൻ സഹായിക്കുന്ന വ്യാപകമായ നിർദേശങ്ങളുടെയും മാനുവലുകളുടെയും ശ്രേണി നൽകുന്നു.
+
+## ഉള്ളടക്കം
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - ഡെവലപ്പർമാർക്കുള്ള സംഭാവനകൾ നൽകുന്നതിനും കോൺഫിഗറേഷനുകൾക്കുള്ള നിർദേശങ്ങൾ
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - കോഡിംഗ് കൺവെൻഷനുകൾ, ലോഗ്ഗിംഗ് നയങ്ങൾ, മറ്റ് പരിവർത്തന ഉപകരണങ്ങൾ
+
+------
+
+## Contrib
+
+ഈ ഭാഗം ഡെവലപ്പർമാർക്ക് കോഡ് സംഭാവന നൽകുന്നതിന്റെയും അവരുടെ പരിസ്ഥിതി സജ്ജമാക്കുന്നതിന്റെയും ബന്ധപ്പെട്ട പ്രക്രിയകൾ പിന്തുടരുന്നതിന്റെയും വിശദമായ ഗൈഡ് നൽകുന്നു.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - OpenIM-ൽ കോഡ് എഴുതുന്നതിന്റെ നിയമങ്ങൾ കൺവെൻഷനുകൾ.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - OpenIM-ൽ വികസനം നടത്തുന്നതിന്റെ ഗൈഡ്.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - ചെറി-പിക്കിംഗ് ഓപ്പറേഷനുകൾക്കുള്ള മാർഗ്ഗനിർദേശങ്ങൾ.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - OpenIM-ൽ ഗിറ്റിന്റെ വർക്ക്ഫ്ലോ.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - OpenIM സജ്ജമാക്കുന്നതിനും ആരംഭിക്കുന്നതിനും നിർദേശങ്ങൾ.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - നിങ്ങളുടെ യന്ത്രത്തിൽ ഡോക്കർ ഇൻസ്റ്റാൾ ചെയ്യുന്ന രീതി.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - ലിനക്സിൽ വികസന പരിസ്ഥിതി സജ്ജമാക്കുന്നതിന്റെ ഗൈഡ്.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - ചില പൊതുവായ നടപടികൾ പ്രദേശികമായി നടത്തുന്നതിന്റെ മാർഗ്ഗനിർദേശങ്ങൾ.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - OpenIM ഓഫ്‌ലൈൻ ഡിപ്ലോയ് ചെയ്യുന്ന രീതികൾ.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - പ്രോട്ടോക് ഉപകരണങ്ങൾ ഉപയോഗിക്കുന്ന ഗൈഡ്.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Go വേണ്ടി OpenIM-ൽ ഉള്ള ഉപകരണങ്ങളും ലൈബ്രറികളും.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Makefile ഉപകരണങ്ങളുടെയും മികച്ച പ്രാക്ടീസുകളുടെയും ഗൈഡ്.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - സ്ക്രിപ്റ്റുകൾക്കുള്ള മികച്ച പ്രാക്ടീസുകളും ഉപകരണങ്ങളും.
+
+## Conversions
+
+ഈ ഭാഗം OpenIM-ൽ ഉള്ള വിവിധ കൺവെൻഷനുകളെയും നയങ്ങളെയും ആവിഷ്കരിക്കുന്നു, ഇതിൽ കോഡ്, ലോഗുകൾ, പതിപ്പുകൾ എന്നിവ ഉൾപ്പെടുന്നു.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - API കൺവെർഷനുകൾക്കുള്ള നിർദേശങ്ങൾ രീതികൾ.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - OpenIM-ൽ ലോഗ്ഗിംഗ് നയങ്ങൾ കൺവെൻഷനുകൾ.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CD പ്രക്രിയകൾ കൺവെൻഷനുകൾ.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - OpenIM-ൽ കോഡ് കമ്മിറ്റുകൾക്കുള്ള കൺവെൻഷനുകൾ.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - OpenIM-ൽ ഡയറക്ടറി ഘടന കൺവെൻഷനുകൾ.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - പിശക് കോഡുകളുടെ പട്ടിക വിവരണങ്ങൾ.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Go കോഡിനുള്ള കൺവെൻഷനുകൾ പരിവർത്തനങ്ങൾ.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - വിവിധ ആർക്കിടെക്ചറുകൾ ഇമേജ് റെപ്പോസിറ്ററികൾ ഉൾപ്പെടുന്ന OpenIM Docker ഇമേജുകളുടെ മാനേജ്മെന്റ് സ്ട്രാറ്റജീസ്.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - ലോഗ്ഗിംഗിന്റെ കൂടുതൽ വിശദമായ കൺവെൻഷനുകൾ.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - OpenIM പതിപ്പുകൾക്കുള്ള നാമകരണ മാനേജ്മെന്റ് സ്ട്രാറ്റജീസ്.
+
+
+## ഡെവലപ്പർമാർക്കും, സംഭാവനകൾ നൽകുന്നവർക്കും, കമ്മ്യൂണിറ്റി മെയിന്റെയിനർമാർക്കും
+
+### ഡെവലപ്പർമാർ & സംഭാവനകൾ നൽകുന്നവർ
+
+നിങ്ങൾ ഒരു ഡെവലപ്പർ അല്ലെങ്കിൽ സംഭാവനകൾ നൽകാൻ ആഗ്രഹിക്കുന്ന ആളാണെങ്കിൽ:
+
+- നിരവധി സംഭാവനകൾ ഉറപ്പാക്കാൻ ഞങ്ങളുടെ [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) എന്നിവയുമായി പരിചിതരാകുക.
+- OpenIM-ൽ വികസന പ്രാക്ടീസുകൾ ലഭ്യമാക്കാൻ [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) അന്വേഷിക്കുക.
+
+### കമ്മ്യൂണിറ്റി മെയിന്റെയിനർമാർ
+
+ഒരു കമ്മ്യൂണിറ്റി മെയിന്റെയിനറായി:
+
+- സംഭാവനകൾ ഞങ്ങളുടെ ഡോക്യുമെന്റേഷനിൽ വിവരിച്ച മാനദണ്ഡങ്ങൾക്ക് അനുസൃതമാണെന്ന് ഉറപ്പാക്കുക.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) എന്നിവ പുതുക്കി വായിക്കുക.
+
+## ഉപയോക്താക്കൾക്ക്
+
+ഉപയോക്താക്കൾ പ്രത്യേകം ശ്രദ്ധിക്കേണ്ട കാര്യങ്ങൾ:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - OpenIM-ന്റെ ഡോക്കർ ഇമേജുകൾ ഉപയോഗിക്കാൻ പദ്ധതിയിടുന്നെങ്കിൽ ആവശ്യമാണ്.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - ലഭ്യമായ വിവിധ ഇമേജുകൾ മനസ്സിലാക്കുകയും നിങ്ങളുടെ ആർക്കിടെക്ചറിന് അനുയോജ്യമായത് എങ്ങനെ തിരഞ്ഞെടുക്കണം എന്ന് അറിയുക.

--- a/docs/README_nl.md
+++ b/docs/README_nl.md
@@ -1,0 +1,67 @@
+# OpenIM Server-documenten
+
+Welkom bij de OpenIM-documentatiehub! Dit centrum biedt een uitgebreide reeks handleidingen en handleidingen die zijn ontworpen om u te helpen het meeste uit uw OpenIM-ervaring te halen.
+
+## Inhoudsopgave
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Richtlijnen voor bijdragen en configuraties voor ontwikkelaars
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Codeerconventies, logboekbeleid en andere transformatietools
+
+------
+
+## Draag bij
+
+Deze sectie biedt ontwikkelaars een gedetailleerde handleiding over hoe ze code kunnen bijdragen, hun omgeving kunnen instellen en de bijbehorende processen kunnen volgen.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Regels en conventies voor het schrijven van code in OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Een handleiding voor het uitvoeren van ontwikkelingen binnen OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Richtlijnen voor kersenplukoperaties.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - De git-workflow in OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Begeleiding bij het instellen en initialiseren van OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Hoe Docker op uw machine te installeren.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Handleiding voor het opzetten van de ontwikkelomgeving op Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Richtlijnen voor het lokaal uitvoeren van bepaalde gemeenschappelijke acties.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Methoden voor het offline inzetten van OpenIM.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Handleiding voor het gebruik van protocoltools.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Tools en bibliotheken in OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Best practices en tools voor Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Best practices en tools voor scripts.
+
+## Conversies
+
+In deze sectie worden verschillende conventies en beleidsregels binnen OpenIM geïntroduceerd, waaronder code, logs, versies en meer.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Richtlijnen en methoden voor API-conversies.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Logboekbeleid en -conventies in OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Procedures en conventies voor CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Conventies voor code-commits in OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Directorystructuur en conventies binnen OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Lijst en beschrijvingen van foutcodes.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Conventies en conversies voor Go-code.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Beheerstrategieën voor OpenIM Docker-images, verspreid over meerdere architecturen en image-opslagplaatsen.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Verdere gedetailleerde conventies over houtkap.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Naamgevings- en beheerstrategieën voor OpenIM-versies.
+
+
+## Voor ontwikkelaars, bijdragers en communitybeheerders
+
+### Ontwikkelaars en bijdragers
+
+Als u een ontwikkelaar bent of iemand die graag een bijdrage wil leveren:
+
+- Maak uzelf vertrouwd met onze [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) en [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) om soepele bijdragen te garanderen.
+- Duik in de [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) om de ontwikkelpraktijken in OpenIM onder de knie te krijgen.
+
+### Gemeenschapsbeheerders
+
+Als gemeenschapsbeheerder:
+
+- Zorg ervoor dat bijdragen in overeenstemming zijn met de normen die in onze documentatie worden beschreven.
+- Controleer regelmatig het [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) en de [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) om op de hoogte te blijven.
+
+## Voor gebruikers
+
+Gebruikers moeten bijzondere aandacht besteden aan:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Noodzakelijk als u van plan bent Docker-images van OpenIM te gebruiken.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Om de verschillende beschikbare afbeeldingen te begrijpen en hoe u de juiste voor uw architectuur kiest.

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -1,0 +1,67 @@
+# Dokumentacja serwera OpenIM
+
+Witamy w centrum dokumentacji OpenIM! Centrum to zapewnia kompleksową gamę przewodników i podręczników zaprojektowanych, aby pomóc Ci w pełni wykorzystać możliwości OpenIM.
+
+## Spis treści
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Wskazówki dotyczące współtworzenia i konfiguracji dla programistów
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Konwencje kodowania, zasady rejestrowania i inne narzędzia do transformacji
+
+------
+
+## Wkład
+
+W tej sekcji deweloperzy mogą znaleźć szczegółowy przewodnik dotyczący udostępniania kodu, konfigurowania środowiska i wykonywania powiązanych procesów.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Zasady i konwencje pisania kodu w OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Poradnik dotyczący programowania w OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Wytyczne dotyczące operacji zbierania wiśni.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Przepływ pracy git w OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Wskazówki dotyczące konfigurowania i inicjowania OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Jak zainstalować Docker na swoim komputerze.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Przewodnik po konfigurowaniu środowiska programistycznego w systemie Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Wytyczne dotyczące sposobu przeprowadzania niektórych typowych działań lokalnie.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Metody wdrażania OpenIM offline.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Przewodnik dotyczący korzystania z narzędzi protoc.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Narzędzia i biblioteki w OpenIM for Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Najlepsze praktyki i narzędzia dla Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Najlepsze praktyki i narzędzia dotyczące skryptów.
+
+## Konwersje
+
+W tej sekcji przedstawiono różne konwencje i zasady w OpenIM, obejmujące kod, dzienniki, wersje i nie tylko.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Wytyczne i metody konwersji API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Zasady i konwencje rejestrowania w OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Procedury i konwencje dotyczące CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Konwencje dotyczące zatwierdzania kodu w OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Struktura katalogów i konwencje w OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Lista i opisy kodów błędów.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Konwencje i konwersje dla kodu Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Strategie zarządzania obrazami Dockera OpenIM obejmujące wiele architektur i repozytoriów obrazów.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Dalsze szczegółowe konwencje dotyczące pozyskiwania drewna.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Strategie nazewnictwa i zarządzania wersjami OpenIM.
+
+
+## Dla programistów, współpracowników i opiekunów społeczności
+
+### Programiści i współpracownicy
+
+Jeśli jesteś programistą lub osobą, która chce wnieść swój wkład:
+
+- Zapoznaj się z naszymi [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) i [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md), aby zapewnić płynną współpracę.
+- Zajrzyj do [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md), aby zapoznać się z praktykami programistycznymi w OpenIM.
+
+### Opiekunowie społeczności
+
+Jako opiekun społeczności:
+
+- Upewnij się, że wkład jest zgodny ze standardami określonymi w naszej dokumentacji.
+- Regularnie przeglądaj [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) i [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md), aby być na bieżąco.
+
+## Dla Użytkowników
+
+Użytkownicy powinni zwrócić szczególną uwagę na:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Niezbędne, jeśli planujesz używać obrazów Dockera OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Aby zrozumieć różne dostępne obrazy i dowiedzieć się, jak wybrać odpowiedni dla swojej architektury.

--- a/docs/README_pt_BR.md
+++ b/docs/README_pt_BR.md
@@ -1,0 +1,67 @@
+# Documentação do Servidor OpenIM
+
+Bem-vindo ao centro de documentação do OpenIM! Este centro oferece uma ampla gama de guias e manuais projetados para ajudá-lo a aproveitar ao máximo sua experiência com o OpenIM.
+
+## Índice de Conteúdos
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Orientações sobre contribuições e configurações para desenvolvedores
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Convenções de codificação, políticas de registro e outras ferramentas de transformação
+
+------
+
+## Contrib
+
+Esta seção oferece aos desenvolvedores um guia detalhado sobre como contribuir com código, configurar seu ambiente e seguir os processos associados.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Regras e convenções para escrever código no OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Um guia sobre como realizar o desenvolvimento dentro do OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Diretrizes sobre operações de cherry-picking.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - O fluxo de trabalho git no OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Orientações sobre configuração e inicialização do OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Como instalar o Docker em sua máquina.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Guia para configurar o ambiente de desenvolvimento no Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Diretrizes sobre como realizar certas ações comuns localmente.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Métodos para implantar o OpenIM offline.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Guia sobre o uso de ferramentas protoc.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Ferramentas e bibliotecas no OpenIM para Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Melhores práticas e ferramentas para Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Melhores práticas e ferramentas para scripts.
+
+## Conversions
+
+Esta seção apresenta várias convenções e políticas dentro do OpenIM, abrangendo código, logs, versões e mais.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Diretrizes e métodos para conversões de API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Políticas e convenções de registro no OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Procedimentos e convenções para CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Convenções para commits de código no OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Estrutura de diretórios e convenções dentro do OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Lista e descrições de códigos de erro.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Convenções e conversões para código Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Estratégias de gerenciamento para imagens Docker do OpenIM, abrangendo várias arquiteturas e repositórios de imagens.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Convenções mais detalhadas sobre registro.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Estratégias de nomeação e gerenciamento para versões do OpenIM.
+
+
+## Para Desenvolvedores, Contribuidores e Mantenedores da Comunidade
+
+### Desenvolvedores & Contribuidores
+
+Se você é um desenvolvedor ou alguém interessado em contribuir:
+
+- Familiarize-se com nossas [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) e [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) para garantir contribuições suaves.
+- Mergulhe no [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) para se familiarizar com as práticas de desenvolvimento no OpenIM.
+
+### Mantenedores da Comunidade
+
+Como mantenedor da comunidade:
+
+- Garanta que as contribuições estejam alinhadas com os padrões descritos em nossa documentação.
+- Reveja regularmente a [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) e [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) para se manter atualizado.
+
+## Para Usuários
+
+Os usuários devem prestar atenção especial a:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Necessário se você planeja usar imagens Docker do OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Para entender as diferentes imagens disponíveis e como escolher a certa para a sua arquitetura.

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -1,0 +1,67 @@
+# Документация по серверу OpenIM
+
+Добро пожаловать в центр документации OpenIM! Этот центр предоставляет широкий спектр руководств и руководств, призванных помочь вам максимально эффективно использовать возможности OpenIM.
+
+## Оглавление
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Руководство по участию и настройке для разработчиков
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Соглашения по кодированию, политики ведения журналов и другие инструменты преобразования.
+
+------
+
+## Вклад
+
+В этом разделе разработчикам предлагается подробное руководство о том, как добавлять код, настраивать среду и следовать соответствующим процессам.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Правила и соглашения по написанию кода в OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Руководство о том, как вести разработку в OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Руководство по сбору урожая.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Рабочий процесс git в OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Руководство по настройке и инициализации OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Как установить Docker на свой компьютер.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Руководство по настройке среды разработки в Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Рекомендации о том, как выполнять определенные общие действия на местном уровне.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Способы развертывания OpenIM в автономном режиме.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Руководство по использованию инструментов протокола.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Инструменты и библиотеки в OpenIM для Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Лучшие практики и инструменты для Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Лучшие практики и инструменты для сценариев.
+
+## Конверсии
+
+В этом разделе представлены различные соглашения и политики OpenIM, включая код, журналы, версии и многое другое.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Рекомендации и методы преобразования API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Политики и соглашения ведения журналов в OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Процедуры и соглашения для CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Соглашения о фиксации кода в OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Структура каталогов и соглашения в OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Список и описание кодов ошибок.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Соглашения и преобразования для кода Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Стратегии управления образами OpenIM Docker, охватывающими несколько архитектур и репозиториев изображений.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Дальнейшие подробные соглашения о ведении журнала.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Стратегии именования и управления версиями OpenIM.
+
+
+## Для разработчиков, участников и сопровождающих сообщества
+
+### Разработчики и участники
+
+Если вы разработчик или кто-то хочет внести свой вклад:
+
+- Ознакомьтесь с нашими [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) и [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md), чтобы обеспечить бесперебойную работу.
+- Погрузитесь в [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md), чтобы ознакомиться с методами разработки в OpenIM.
+
+### Сопровождающие сообщества
+
+Как администратор сообщества:
+
+- Убедитесь, что вклады соответствуют стандартам, изложенным в нашей документации.
+- Регулярно просматривайте [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) и [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md), чтобы оставаться в курсе событий.
+
+## Для пользователей
+
+Пользователям следует обратить особое внимание на:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Необходимо, если вы планируете использовать Docker-образы OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Чтобы понять различные доступные изображения и как выбрать подходящее для вашей архитектуры.

--- a/docs/README_tr.md
+++ b/docs/README_tr.md
@@ -1,0 +1,67 @@
+# OpenIM Sunucu Belgeleri
+
+OpenIM Belgeleri merkezine hoş geldiniz! Bu merkez, OpenIM deneyiminizden en iyi şekilde faydalanmanıza yardımcı olmak için tasarlanmış kapsamlı bir rehber ve kılavuzlar koleksiyonu sunar.
+
+## İçindekiler
+
+1. [Katılım](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Geliştiriciler için katkıda bulunma ve yapılandırma rehberi
+2. [Dönüşümler](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Kodlama kuralları, günlükleme politikaları ve diğer dönüşüm araçları
+
+------
+
+## Katılım
+
+Bu bölüm, geliştiricilere kod katkısında bulunma, çevrelerini kurma ve ilişkilendirilmiş süreçleri takip etme konusunda detaylı bir rehber sunar.
+
+- [Kod Kuralları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - OpenIM'de kod yazma kuralları ve gelenekleri.
+- [Geliştirme Rehberi](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - OpenIM içinde geliştirme nasıl yapılır konusunda bir rehber.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Cherry-pick işlemleri için yönergeler.
+- [Git Çalışma Akışı](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - OpenIM'deki git çalışma akışı.
+- [Başlangıç Yapılandırmaları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - OpenIM'i kurma ve başlatma konusunda rehberlik.
+- [Docker Kurulumu](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Makinenize Docker nasıl kurulur.
+- [Linux Geliştirme Ortamı](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Linux üzerinde geliştirme ortamını kurma kılavuzu.
+- [Yerel İşlemler](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Yerelde belirli yaygın işlemleri nasıl gerçekleştireceğiniz hakkında yönergeler.
+- [Çevrimdışı Dağıtım](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - OpenIM'in çevrimdışı nasıl dağıtılacağı yöntemleri.
+- [Protoc Araçları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Protoc araçlarını kullanma rehberi.
+- [Go Araçları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Go için OpenIM'deki araçlar ve kütüphaneler.
+- [Makefile Araçları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Makefile için en iyi uygulamalar ve araçlar.
+- [Betik Araçları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Betikler için en iyi uygulamalar ve araçlar.
+
+## Dönüşümler
+
+Bu bölüm, kod, günlükler, sürümler ve daha fazlasını içeren çeşitli OpenIM içindeki kuralları ve politikaları tanıtır.
+
+- [API Dönüşümleri](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - API dönüşümleri için yönergeler ve yöntemler.
+- [Günlükleme Politikası](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - OpenIM'deki günlükleme politikaları ve gelenekleri.
+- [CI/CD İşlemleri](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CD için prosedürler ve gelenekler.
+- [Taahhüt Kuralları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - OpenIM'deki kod taahhütleri için kurallar.
+- [Dizin Kuralları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - OpenIM içindeki dizin yapısı ve kurallar.
+- [Hata Kodları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Hata kodlarının listesi ve açıklamaları.
+- [Go Kod Dönüşümleri](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Go kodu için kurallar ve dönüşümler.
+- [Docker İmaj Stratejisi](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - OpenIM Docker imajlarının yönetim stratejileri, birden fazla mimariyi ve imaj depolarını kapsar.
+- [Günlükleme Kuralları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Günlükleme hakkında daha fazla ayrıntılı kurallar.
+- [Sürüm Kuralları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - OpenIM sürümleri için adlandırma ve yönetim stratejileri.
+
+
+## Geliştiriciler, Katkıda Bulunanlar ve Topluluk Bakımı
+
+### Geliştiriciler & Katkıda Bulunanlar
+
+Eğer bir geliştirici veya katkıda bulunmaya hevesli biriyseniz:
+
+- Katkılarınızı düzgün bir şekilde yapmak için [Kod Kuralları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) ve [Git Çalışma Akışı](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) ile tanışın.
+- OpenIM'deki geliştirme uygulamalarını anlamak için [Geliştirme Rehberi'ne](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) göz atın.
+
+### Topluluk Bakımı
+
+Topluluk bakımı olarak:
+
+- Katkıların belirtilen standartlarla uyumlu olduğundan emin olun.
+- [Günlükleme Politikası](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) ve [Hata Kodları](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) sık sık gözden geçirerek güncel kalın.
+
+## Kullanıcılar İçin
+
+Kullanıcılar, özellikle dikkat etmelidir:
+
+- [Docker Kurulumu](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - OpenIM Docker imajlarını kullanmayı planlıyorsanız gereklidir.
+- [Docker İmaj Stratejisi](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Mevcut farklı imajları anlamak ve mimarinize uygun olanı nasıl seçeceğinizi öğrenmek için.

--- a/docs/README_ua.md
+++ b/docs/README_ua.md
@@ -1,0 +1,67 @@
+# OpenIM Server документ
+
+Ласкаво просимо до Центру документації OpenIM! Цей центр надає вичерпні посібники та посібники, розроблені, щоб допомогти вам отримати максимальну віддачу від роботи з OpenIM.
+
+## Зміст
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Посібник із внесків і налаштування для розробників
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Інструкції з кодування, політики журналювання та інші інструменти перетворення
+
+------
+
+## Посібник із внесків
+
+Цей розділ надає розробникам докладні вказівки щодо того, як додати код, налаштувати своє середовище та дотримуватися пов’язаних процесів.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Правила та умовності для написання коду в OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Посібник з розробки в OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Ретельно підібрані інструкції.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - робочий процес git у OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Посібник із налаштування та ініціалізації OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Як встановити Docker на вашу машину.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Посібник із налаштування середовища розробки в Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Посібник із виконання деяких типових операцій локально.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Як розгорнути OpenIM офлайн.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Посібник із використання інструменту protoc.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Інструменти та бібліотеки для Go в OpenIM.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Найкращі практики та інструменти для Makefiles.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Найкращі практики та інструменти для створення сценаріїв.
+
+## Методи внеску
+
+У цьому розділі описано різні практики та політики в OpenIM, зокрема код, журнали, версії тощо.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Рекомендації та методи перетворення API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Політика та практика журналювання в OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Процедури та практики CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Конвенції для подання коду в OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Конвенції для подання коду в OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Перелік і опис кодів помилок.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Конвенції та перетворення коду Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Стратегія керування зображеннями OpenIM Docker, що охоплює кілька архітектур і сховищ зображень.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Більш детальні умови для журналювання.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Стратегії іменування та керування для версій OpenIM.
+
+
+## Для розробників, співавторів і супроводжувачів спільноти
+
+### Розробники та учасники
+
+Якщо ви розробник або бажаєте зробити внесок:
+
+- знайомі з нами [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) і [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md), щоб забезпечити плавний внесок.
+- зрозуміти глибше [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md), освоїти практики розробки OpenIM.
+
+### супроводжувач спільноти
+
+Як супроводжувач спільноти:
+
+- Переконайтеся, що внески відповідають стандартам, викладеним у нашій документації.
+- Регулярно перевіряйте [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) i [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md), щоб бути в курсі подій.
+
+## Для користувачів
+
+Користувачам слід звернути особливу увагу на:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Це буде необхідно, якщо ви плануєте використовувати образ Docker OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Дізнайтеся про доступні зображення та про те, як вибрати правильний для вашої архітектури.

--- a/docs/README_vi.md
+++ b/docs/README_vi.md
@@ -1,0 +1,67 @@
+# Tài liệu Máy chủ OpenIM
+
+Chào mừng bạn đến với trung tâm tài liệu OpenIM! Trung tâm này cung cấp một loạt các hướng dẫn và hướng dẫn chi tiết được thiết kế để giúp bạn tận dụng tối đa trải nghiệm OpenIM của mình.
+
+## Mục lục
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Hướng dẫn về đóng góp và cấu hình cho các nhà phát triển
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - Quy ước mã hóa, chính sách ghi nhật ký và các công cụ chuyển đổi khác
+
+------
+
+## Đóng góp
+
+Phần này cung cấp cho các nhà phát triển một hướng dẫn chi tiết về cách đóng góp mã, thiết lập môi trường của họ và tuân theo các quy trình liên quan.
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - Quy tắc và quy ước viết mã trong OpenIM.
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - Hướng dẫn về cách thực hiện phát triển trong OpenIM.
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - Hướng dẫn về các hoạt động chọn lọc.
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - Quy trình làm việc git trong OpenIM.
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - Hướng dẫn về thiết lập và khởi tạo OpenIM.
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Cách cài đặt Docker trên máy của bạn.
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Hướng dẫn thiết lập môi trường phát triển trên Linux.
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - Hướng dẫn về cách thực hiện một số hành động phổ biến ở cấp địa phương.
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - Các phương pháp triển khai OpenIM ngoại tuyến.
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - Hướng dẫn sử dụng công cụ protoc.
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - Công cụ và thư viện trong OpenIM cho Go.
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Thực hành tốt nhất và công cụ cho Makefile.
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - Thực hành tốt nhất và công cụ cho kịch bản.
+
+## Chuyển đổi
+
+Phần này giới thiệu các quy ước và chính sách khác nhau trong OpenIM, bao gồm mã, nhật ký, phiên bản và hơn thế nữa.
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - Hướng dẫn và phương pháp chuyển đổi API.
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - Chính sách và quy ước ghi nhật ký trong OpenIM.
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - Quy trình và quy ước cho CI/CD.
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - Quy ước cho các cam kết mã trong OpenIM.
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - Cấu trúc thư mục và quy ước trong OpenIM.
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - Danh sách và mô tả các mã lỗi.
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Quy ước và chuyển đổi cho mã Go.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Chiến lược quản lý hình ảnh Docker của OpenIM, bao gồm nhiều kiến trúc và kho lưu trữ hình ảnh.
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - Quy ước chi tiết hơn về ghi nhật ký.
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - Chiến lược đặt tên và quản lý phiên bản OpenIM.
+
+
+## Dành cho Nhà phát triển, Người đóng góp và Người duy trì Cộng đồng
+
+### Nhà phát triển & Người đóng góp
+
+Nếu bạn là nhà phát triển hoặc ai đó muốn đóng góp:
+
+- Làm quen với [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) và [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) của chúng tôi để đảm bảo đóng góp trôi chảy.
+- Tìm hiểu [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) để nắm bắt các thực hành phát triển trong OpenIM.
+
+### Người duy trì Cộng đồng
+
+Là người duy trì cộng đồng:
+
+- Đảm bảo rằng các đóng góp phù hợp với các tiêu chuẩn được nêu trong tài liệu của chúng tôi.
+- Thường xuyên xem lại [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) và [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) để cập nhật thông tin.
+
+## Dành cho Người dùng
+
+Người dùng nên chú ý đặc biệt đến:
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - Cần thiết nếu bạn dự định sử dụng hình ảnh Docker của OpenIM.
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - Để hiểu các hình ảnh khác nhau có sẵn và cách chọn hình ảnh phù hợp cho kiến trúc của bạn.

--- a/docs/README_zh_CN.md
+++ b/docs/README_zh_CN.md
@@ -1,0 +1,67 @@
+# OpenIM Server 文档
+
+欢迎来到 OpenIM 文档中心！本中心提供全面的指南和手册，旨在帮助您最大限度地利用 OpenIM 体验。
+
+## 目录
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - 为开发者提供的贡献指南和配置
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - 编码规范、日志策略和其他转换工具
+
+------
+
+## 贡献指南
+
+本节为开发人员提供了如何贡献代码、设置环境以及遵循相关流程的详细指南。
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - OpenIM 中编写代码的规则和惯例。
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - 关于如何在 OpenIM 内进行开发的指南。
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - 精挑细选的操作指南。
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - OpenIM 中的 git 工作流程。
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - 设置和初始化 OpenIM 的指南。
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - 如何在您的机器上安装 Docker。
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - 在 Linux 上设置开发环境的指南。
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - 关于如何在本地执行某些常见操作的指南。
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - 离线部署 OpenIM 的方法。
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - 使用 protoc 工具的指南。
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - OpenIM 中 Go 的工具和库。
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Makefile 的最佳实践和工具。
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - 脚本的最佳实践和工具。
+
+## 贡献方法
+
+本节介绍 OpenIM 内的各种惯例和政策，包括代码、日志、版本等。
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - API 转换的指南和方法。
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - OpenIM 中的日志策略和惯例。
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CD 的程序和惯例。
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - OpenIM 中代码提交的惯例。
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - OpenIM 内的目录结构和惯例。
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - 错误代码的列表和描述。
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Go 代码的惯例和转换。
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - OpenIM Docker 镜像的管理策略，涵盖多个架构和镜像仓库。
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - 有关日志的更详细的惯例。
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - OpenIM 版本的命名和管理策略。
+
+
+## 对于开发者、贡献者和社区维护者
+
+### 开发者和贡献者
+
+如果您是一名开发者或热衷于贡献：
+
+- 熟悉我们的 [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) 和 [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md)，以确保顺利贡献。
+- 深入了解 [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md)，掌握 OpenIM 的开发实践。
+
+### 社区维护者
+
+作为社区维护者：
+
+- 确保贡献符合我们文档中概述的标准。
+- 定期查看 [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) 和 [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md)，以保持最新状态。
+
+## 对于用户
+
+用户应特别注意：
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - 如果您计划使用 OpenIM 的 Docker 镜像，那么这个将会是必须的。
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - 了解可用的镜像以及如何为您的架构选择正确的镜像。

--- a/docs/README_zh_TW.md
+++ b/docs/README_zh_TW.md
@@ -1,0 +1,67 @@
+# OpenIM 伺服器文檔
+
+歡迎來到 OpenIM 文件中心！ 該中心提供全面的指南和手冊，旨在幫助您充分利用 OpenIM 體驗。
+
+## 目錄
+
+1. [Contrib](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - 開發人員貢獻和配置指南
+2. [Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib) - 編碼約定、日誌記錄策略和其他轉換工具
+
+------
+
+## 貢獻
+
+本節為開發人員提供了有關如何貢獻程式碼、設定環境以及遵循相關流程的詳細指南。
+
+- [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) - 在 OpenIM 中編寫程式碼的規則和約定。
+- [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) - 有關如何在 OpenIM 中進行開發的指南。
+- [Git Cherry Pick](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/gitcherry-pick.md) - 精挑細選操作指南。
+- [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) - OpenIM 中的 git 工作流程。
+- [Initialization Configurations](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/init-config.md) - 設定和初始化 OpenIM 的指南。
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - 如何在您的電腦上安裝 Docker。
+- [Linux Development Environment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/linux-development.md) - Linux 上的開發環境設定指南。
+- [Local Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/local-actions.md) - 關於如何在當地進行某些共同行動的指南。
+- [Offline Deployment](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/offline-deployment.md) - 離線部署OpenIM的方法。
+- [Protoc Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/protoc-tools.md) - 協議工具使用指南。
+- [Go Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-go.md) - OpenIM 在 Go 中的工具和函式庫。
+- [Makefile Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-makefile.md) - Makefile 的最佳實務和工具。
+- [Script Tools](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/util-scripts.md) - 腳本的最佳實踐和工具。
+
+## 轉換
+
+本節介紹 OpenIM 中的各種約定和策略，包括程式碼、日誌、版本等。
+
+- [API Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/api.md) - API 轉換的指南和方法。
+- [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) - OpenIM 中的日誌記錄策略和約定。
+- [CI/CD Actions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/cicd-actions.md) - CI/CD 的程序和約定。
+- [Commit Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/commit.md) - OpenIM 中程式碼提交的約定。
+- [Directory Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/directory.md) - OpenIM 中的目錄結構和約定。
+- [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) - 錯誤代碼的清單和描述。
+- [Go Code Conversions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/go-code.md) - Go 程式碼的約定和轉換。
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - OpenIM Docker 映像的管理策略，跨越多種架構和映像儲存庫。
+- [Logging Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/logging.md) - 有關日誌記錄的更詳細約定。
+- [Version Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/version.md) - OpenIM 版本的命名與管理策略。
+
+
+## 對於開發者、貢獻者和社區維護者
+
+### 開發者和貢獻者
+
+如果您是開發人員或熱衷於做出貢獻的人：
+
+- 熟悉我們的 [Code Conventions](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/code-conventions.md) 和 [Git Workflow](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/git-workflow.md) 以確保順利貢獻。
+- 深入閱讀 [Development Guide](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/development.md) ，掌握 OpenIM 的開發實務。
+
+### 社區維護者
+
+作為社區維護者：
+
+- 確保貢獻符合我們文件中概述的標準。
+- 定期查看 [Logging Policy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/bash-log.md) 和 [Error Codes](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/error-code.md) 以保持更新。
+
+## 對於用戶
+
+使用者應特別注意：
+
+- [Docker Installation](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/install-docker.md) - 如果您打算使用 OpenIM 的 Docker 映像，則這是必要的。
+- [Docker Image Strategy](https://github.com/openimsdk/open-im-server/blob/main/docs/contrib/images.md) - 了解可用的不同影像以及如何為您的架構選擇正確的影像。


### PR DESCRIPTION
Added README.md files in multiple languages
include:
Simplified Chinese, Traditional Chinese, Arabic, etc., a total of 25 languages.
Help improve accessibility and make it easier for contributors to join us.