### PR TITLE
fix: Add Descending Sort by Creation Time to Group Search & Fix Admin Update Error

### DIFF
--- a/pkg/common/db/mgo/group.go
+++ b/pkg/common/db/mgo/group.go
@@ -16,8 +16,9 @@ package mgo
 
 import (
 	"context"
-	"github.com/OpenIMSDK/protocol/constant"
 	"time"
+
+	"github.com/OpenIMSDK/protocol/constant"
 
 	"github.com/OpenIMSDK/tools/errs"
 	"github.com/OpenIMSDK/tools/mgoutil"
@@ -70,8 +71,12 @@ func (g *GroupMgo) Take(ctx context.Context, groupID string) (group *relation.Gr
 }
 
 func (g *GroupMgo) Search(ctx context.Context, keyword string, pagination pagination.Pagination) (total int64, groups []*relation.GroupModel, err error) {
-	return mgoutil.FindPage[*relation.GroupModel](ctx, g.coll, bson.M{"group_name": bson.M{"$regex": keyword},
-		"status": bson.M{"$ne": constant.GroupStatusDismissed}}, pagination)
+	opts := options.Find().SetSort(bson.D{{Key: "created_at", Value: -1}})
+
+	return mgoutil.FindPage[*relation.GroupModel](ctx, g.coll, bson.M{
+		"group_name": bson.M{"$regex": keyword},
+		"status":     bson.M{"$ne": constant.GroupStatusDismissed},
+	}, pagination, opts)
 }
 
 func (g *GroupMgo) CountTotal(ctx context.Context, before *time.Time) (count int64, err error) {


### PR DESCRIPTION
Add Descending Sort by Creation Time in Group Search] Optimize the sorting function of group search - According to the previous discussion, in order to improve the user experience when searching for groups, we need to add Descending Sort by Creation Time in Group Search at http:// Added a sorting function in descending order of creation time to the group search results of 14.29.213.197:50002/group/get_groups.  
This will help users find newly created groups faster and improve the way information is presented.

Fix: #2089