### PR TITLE
fix: Fix Incorrect Group Member Count in SearchMessage API  group getGroupMemberIDs is 0 err

### DIFF
--- a/internal/rpc/group/cache.go
+++ b/internal/rpc/group/cache.go
@@ -33,10 +33,7 @@ func (s *groupServer) GetGroupInfoCache(
 	return resp, nil
 }
 
-func (s *groupServer) GetGroupMemberCache(
-	ctx context.Context,
-	req *pbgroup.GetGroupMemberCacheReq,
-) (resp *pbgroup.GetGroupMemberCacheResp, err error) {
+func (s *groupServer) GetGroupMemberCache(ctx context.Context, req *pbgroup.GetGroupMemberCacheReq) (resp *pbgroup.GetGroupMemberCacheResp, err error) {
 	members, err := s.db.TakeGroupMember(ctx, req.GroupID, req.GroupMemberID)
 	if err != nil {
 		return nil, err

--- a/internal/rpc/group/group.go
+++ b/internal/rpc/group/group.go
@@ -951,6 +951,7 @@ func (s *groupServer) SetGroupInfo(ctx context.Context, req *pbgroup.SetGroupInf
 		return nil, errs.Wrap(errs.ErrDismissedAlready)
 	}
 	resp := &pbgroup.SetGroupInfoResp{}
+
 	count, err := s.db.FindGroupMemberNum(ctx, group.GroupID)
 	if err != nil {
 		return nil, err
@@ -1077,6 +1078,7 @@ func (s *groupServer) GetGroups(ctx context.Context, req *pbgroup.GetGroupsReq) 
 		total, group, err = s.db.SearchGroup(ctx, req.GroupName, req.Pagination)
 		resp.Total = uint32(total)
 	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1084,10 +1086,12 @@ func (s *groupServer) GetGroups(ctx context.Context, req *pbgroup.GetGroupsReq) 
 	groupIDs := utils.Slice(group, func(e *relationtb.GroupModel) string {
 		return e.GroupID
 	})
+
 	ownerMembers, err := s.db.FindGroupsOwner(ctx, groupIDs)
 	if err != nil {
 		return nil, err
 	}
+
 	ownerMemberMap := utils.SliceToMap(ownerMembers, func(e *relationtb.GroupMemberModel) string {
 		return e.GroupID
 	})

--- a/pkg/authverify/token.go
+++ b/pkg/authverify/token.go
@@ -60,6 +60,7 @@ func CheckAdmin(ctx context.Context, config *config.GlobalConfig) error {
 	}
 	return errs.ErrNoPermission.Wrap(fmt.Sprintf("user %s is not admin userID", mcontext.GetOpUserID(ctx)))
 }
+
 func CheckIMAdmin(ctx context.Context, config *config.GlobalConfig) error {
 	if utils.IsContain(mcontext.GetOpUserID(ctx), config.IMAdmin.UserID) {
 		return nil

--- a/pkg/rpcclient/group.go
+++ b/pkg/rpcclient/group.go
@@ -49,11 +49,7 @@ func NewGroupRpcClient(discov discoveryregistry.SvcDiscoveryRegistry, config *co
 	return GroupRpcClient(*NewGroup(discov, config))
 }
 
-func (g *GroupRpcClient) GetGroupInfos(
-	ctx context.Context,
-	groupIDs []string,
-	complete bool,
-) ([]*sdkws.GroupInfo, error) {
+func (g *GroupRpcClient) GetGroupInfos(ctx context.Context, groupIDs []string, complete bool) ([]*sdkws.GroupInfo, error) {
 	resp, err := g.Client.GetGroupsInfo(ctx, &group.GetGroupsInfoReq{
 		GroupIDs: groupIDs,
 	})
@@ -184,11 +180,7 @@ func (g *GroupRpcClient) GetGroupInfoCache(ctx context.Context, groupID string) 
 	return resp.GroupInfo, nil
 }
 
-func (g *GroupRpcClient) GetGroupMemberCache(
-	ctx context.Context,
-	groupID string,
-	groupMemberID string,
-) (*sdkws.GroupMemberFullInfo, error) {
+func (g *GroupRpcClient) GetGroupMemberCache(ctx context.Context, groupID string, groupMemberID string) (*sdkws.GroupMemberFullInfo, error) {
 	resp, err := g.Client.GetGroupMemberCache(ctx, &group.GetGroupMemberCacheReq{
 		GroupID:       groupID,
 		GroupMemberID: groupMemberID,


### PR DESCRIPTION
<br>

<!--
#### 🫰Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
📇 https://github.com/OpenIMSDK/Open-IM-Server/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR.
-->
#### 🔍 What type of PR is this?

/kind bug


<!--
We need to tag this PR, which you should learn about in the contributor guide.

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### 👀 What this PR does / why we need it:
<!-- What this PR does? -->
<!-- Make sure your pr passes the CI checks and do check the following fields as needed -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

<!--Why do we need this PR?-->

This PR addresses a bug in the `SearchMessage` API where the member count for groups was incorrectly displayed as zero during automated testing and script execution. The root cause was identified as a lack of direct integration with the group member count retrieval in the search logic. To resolve this issue, we have modified the `SearchMessage` function to incorporate an accurate count of group members by leveraging the `GetGroupMemberIDs` method from the `GroupLocalCache`. This ensures the `GroupMemberCount` in the response accurately reflects the actual number of members in a group, enhancing both data accuracy and the effectiveness of automated tests. 

Changes include:
- Utilizing `GetGroupMemberIDs` to fetch the real member count for each group encountered in chat logs.
- Updating the `GroupMemberCount` in the `SearchMessageResp` to accurately reflect the fetched member counts.
- Ensuring the integrity of the search function and improving the reliability of data used in testing scenarios.



#### 🅰 Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If there are multiple PRS, use `Resolves #10, resolves #123, resolves octo-org/octo-repo#100`
If there is a relevant PR, use `octo-org/octo-repo#123`
-->

Fixes #2097

#### 📝 Special notes for your reviewer:

<!-- What else would you tell someone who reviews your code -->

#### 🎯 Describe how to verify it

![image](https://github.com/openimsdk/open-im-server/assets/86140903/1e6fad4e-c85d-442a-8aa8-6f64153ac09a)
