### PR TITLE
docs: Optimize Deployment Speed for Users in China with Aliyun Image Registry

### DIFF
--- a/docs/contrib/images.md
+++ b/docs/contrib/images.md
@@ -96,4 +96,21 @@ When pulling OpenIM's Docker images, you can choose the most suitable source bas
 
 3. Run the `docker images` command to confirm that the image has been successfully pulled.
 
-This concludes OpenIM's image management strategy and the steps for pulling images. If you have any questions, please feel free to ask.
+### Accelerating Deployment for Users in China with Aliyun Mirror or Alternative Image Addresses
+
+For users in China looking to speed up the deployment process of OpenIM, leveraging a mirror image address is a highly recommended practice. After executing the `make init` command, a `.env` file is generated, which you'll need to edit to configure the image registry source. This configuration is crucial for optimizing download speeds and ensuring a smoother setup process.
+
+Within the generated `.env` file, you'll find a section dedicated to choosing the image address. It includes options for GitHub (`ghcr.io/openimsdk`), Docker Hub (`openim`), and Ali Cloud (`registry.cn-hangzhou.aliyuncs.com/openimsdk`). To achieve the best performance within China, it is advised to use the Aliyun image address. 
+
+To do this, you need to comment out the current `IMAGE_REGISTRY` setting and uncomment the Aliyun option. Here is how you can adjust it for Aliyun:
+
+```bash
+# Choose the image address: GitHub (ghcr.io/openimsdk), Docker Hub (openim), 
+# or Ali Cloud (registry.cn-hangzhou.aliyuncs.com/openimsdk).
+# Uncomment one of the following three options. Aliyun is recommended for users in China.
+# IMAGE_REGISTRY="ghcr.io/openimsdk"
+# IMAGE_REGISTRY="openim"
+IMAGE_REGISTRY="registry.cn-hangzhou.aliyuncs.com/openimsdk"
+```
+
+This change directs the deployment process to fetch the required images from the Aliyun registry, significantly improving download and installation speeds due to the geographical and network advantages within China. If, for any reason, you prefer not to use Aliyun or encounter issues, consider switching to another mirror address listed in the `.env` file by following the same uncommenting process. This flexibility ensures that users can select the most suitable image source for their specific situation, leading to a more efficient deployment of OpenIM.


### PR DESCRIPTION
**Description:**
This PR introduces an optimization for users in China aiming to deploy OpenIM more efficiently. By default, the `.env` file generated after executing `make init` offers several options for the image registry, including GitHub, Docker Hub, and Ali Cloud. Recognizing the network latency and download speed challenges within China, this update highlights the recommendation of using the Aliyun image address for such users.

**Changes:**
- Updated the `.env` file template within the deployment scripts to emphasize the Aliyun registry (`registry.cn-hangzhou.aliyuncs.com/openimsdk`) as the recommended option for users in China.
- Added comments in the `.env` file to guide users on how to switch the `IMAGE_REGISTRY` variable to Aliyun for optimal download speeds.
- Provided instructions in the documentation on how to modify the `.env` file accordingly, catering to users who might prefer using alternatives like GitHub or Docker Hub, depending on their location and network conditions.