### PR TITLE
fix bug:invalid go version '1.21.2' : must match format 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openimsdk/open-im-server/v3
 
-go 1.21.2
+go 1.21
 
 require (
 	firebase.google.com/go v3.13.0+incompatible


### PR DESCRIPTION


This error may be encountered on centos 7

issue  #2229

It has now been fixed, changing the three-digit version number to two-digit