### PR TITLE
feat: add webhook AttentionIds

### DIFF
--- a/config/webhooks.yml
+++ b/config/webhooks.yml
@@ -13,6 +13,9 @@ afterUpdateUserInfoEx:
 afterSendSingleMsg:
   enable: false
   timeout: 5
+  # Only the senID/recvID specified in attentionIds will send the callback
+  # if not set, all user messages will be callback
+  attentionIds: []
 beforeSendGroupMsg:
   enable: false
   timeout: 5

--- a/internal/rpc/msg/callback.go
+++ b/internal/rpc/msg/callback.go
@@ -83,6 +83,11 @@ func (m *msgServer) webhookAfterSendSingleMsg(ctx context.Context, after *config
 	if msg.MsgData.ContentType == constant.Typing {
 		return
 	}
+	// According to the attentionIds configuration, only some users are sent
+	attentionIds := after.AttentionIds
+	if attentionIds != nil && !datautil.Contain(msg.MsgData.RecvID, attentionIds...) && !datautil.Contain(msg.MsgData.SendID, attentionIds...) {
+		return
+	}
 	cbReq := &cbapi.CallbackAfterSendSingleMsgReq{
 		CommonCallbackReq: toCommonCallback(ctx, msg, cbapi.CallbackAfterSendSingleMsgCommand),
 		RecvID:            msg.MsgData.RecvID,

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -339,8 +339,9 @@ type BeforeConfig struct {
 }
 
 type AfterConfig struct {
-	Enable  bool `mapstructure:"enable"`
-	Timeout int  `mapstructure:"timeout"`
+	Enable       bool  `mapstructure:"enable"`
+	Timeout      int   `mapstructure:"timeout"`
+	AttentionIds []string `mapstructure:"attentionIds"`
 }
 
 type Share struct {


### PR DESCRIPTION
I noticed that the afterSendSingleMsg webhook can trigger a callback after a message is sent. This appears to be global, meaning every message will callback to the business server. This is quite resource-intensive for scenarios where only messages from certain users need to be monitored. I have added a configuration option to set the users whose message callbacks need to be monitored in the configuration file. The judgment is completed on the OpenIM side, and only the corresponding users will trigger the hook. This approach can be applied to all webhooks; I have currently only implemented the handling for afterSendSingleMsg.

For example, in a customer service bot scenario, the existing webhook cannot monitor only the messages sent to the customer service account. To achieve this functionality, all user messages would have to be monitored, leading to unnecessary resource consumption.