### PR TITLE
fix: #2410 BeforeMemberJoinGroup callback member error

### DIFF
--- a/internal/rpc/group/group.go
+++ b/internal/rpc/group/group.go
@@ -442,7 +442,7 @@ func (s *groupServer) InviteUserToGroup(ctx context.Context, req *pbgroup.Invite
 			MuteEndTime:    time.UnixMilli(0),
 		}
 
-		if err := s.webhookBeforeMemberJoinGroup(ctx, &s.config.WebhooksConfig.BeforeMemberJoinGroup, groupMember, group.Ex); err != nil && err != servererrs.ErrCallbackContinue {
+		if err := s.webhookBeforeMemberJoinGroup(ctx, &s.config.WebhooksConfig.BeforeMemberJoinGroup, member, group.Ex); err != nil && err != servererrs.ErrCallbackContinue {
 			return nil, err
 		}
 		groupMembers = append(groupMembers, member)


### PR DESCRIPTION
The current code callback object is the current operating user; it should callback the member information being operated on.
#### 🅰 Please add the issue ID after "Fixes #"
Fixes #2410 