### PR TITLE
fix: the attribute version is obsolete, remove it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   openim:
     driver: bridge


### PR DESCRIPTION
$ docker-compose --version
Docker Compose version v2.29.1-desktop.1

WARN[0000] open-im-server/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion