### PR TITLE
fix: Change group member roleLevel can`t send notification

### DIFF
--- a/internal/rpc/group/group.go
+++ b/internal/rpc/group/group.go
@@ -1621,7 +1621,7 @@ func (g *groupServer) SetGroupMemberInfo(ctx context.Context, req *pbgroup.SetGr
 				g.notification.GroupMemberSetToOrdinaryUserNotification(ctx, member.GroupID, member.UserID)
 			}
 		}
-		if member.Nickname != nil || member.FaceURL != nil || member.Ex != nil {
+		if member.Nickname != nil || member.FaceURL != nil || member.Ex != nil || member.RoleLevel != nil {
 			g.notification.GroupMemberInfoSetNotification(ctx, member.GroupID, member.UserID)
 		}
 	}


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #2776
fix: Change group member roleLevel can`t send notification