### PR TITLE
resolve the prometheus discovery issue of same service‘s multiple instances in v3.8.3

### DIFF
--- a/internal/api/init.go
+++ b/internal/api/init.go
@@ -26,7 +26,6 @@ import (
 	"github.com/openimsdk/tools/errs"
 	"github.com/openimsdk/tools/log"
 	"github.com/openimsdk/tools/system/program"
-	"github.com/openimsdk/tools/utils/jsonutil"
 )
 
 type Config struct {
@@ -96,10 +95,7 @@ func Start(ctx context.Context, index int, cfg *Config) error {
 
 			etcdClient := client.(*etcd.SvcDiscoveryRegistryImpl).GetClient()
 
-			_, err = etcdClient.Put(ctx, prommetrics.BuildDiscoveryKey(prommetrics.APIKeyName), jsonutil.StructToJsonString(prommetrics.BuildDefaultTarget(registerIP, prometheusPort)))
-			if err != nil {
-				return errs.WrapMsg(err, "etcd put err")
-			}
+			prommetrics.Register(ctx, etcdClient, prommetrics.APIKeyName, registerIP, prometheusPort)
 		} else {
 			prometheusPort, err = datautil.GetElemByIndex(cfg.API.Prometheus.Ports, index)
 			if err != nil {

--- a/internal/api/prometheus_discovery.go
+++ b/internal/api/prometheus_discovery.go
@@ -38,7 +38,7 @@ func (p *PrometheusDiscoveryApi) Enable(c *gin.Context) {
 }
 
 func (p *PrometheusDiscoveryApi) discovery(c *gin.Context, key string) {
-	eResp, err := p.client.Get(c, prommetrics.BuildDiscoveryKey(key))
+	eResp, err := p.client.Get(c, prommetrics.BuildDiscoveryKeyPrefix(key))
 	if err != nil {
 		// Log and respond with an error if preparation fails.
 		apiresp.GinError(c, errs.WrapMsg(err, "etcd get err"))

--- a/internal/msgtransfer/init.go
+++ b/internal/msgtransfer/init.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 
 	"github.com/openimsdk/tools/discovery/etcd"
-	"github.com/openimsdk/tools/utils/jsonutil"
 	"github.com/openimsdk/tools/utils/network"
 
 	"github.com/openimsdk/open-im-server/v3/pkg/common/prommetrics"
@@ -178,10 +177,7 @@ func (m *MsgTransfer) Start(index int, cfg *Config) error {
 
 			etcdClient := client.(*etcd.SvcDiscoveryRegistryImpl).GetClient()
 
-			_, err = etcdClient.Put(context.TODO(), prommetrics.BuildDiscoveryKey(prommetrics.MessageTransferKeyName), jsonutil.StructToJsonString(prommetrics.BuildDefaultTarget(registerIP, prometheusPort)))
-			if err != nil {
-				return errs.WrapMsg(err, "etcd put err")
-			}
+			prommetrics.Register(context.TODO(), etcdClient, prommetrics.MessageTransferKeyName, registerIP, prometheusPort)
 		} else {
 			prometheusPort, err = datautil.GetElemByIndex(cfg.MsgTransfer.Prometheus.Ports, index)
 			if err != nil {

--- a/pkg/common/startrpc/start.go
+++ b/pkg/common/startrpc/start.go
@@ -29,7 +29,6 @@ import (
 	conf "github.com/openimsdk/open-im-server/v3/pkg/common/config"
 	"github.com/openimsdk/tools/discovery/etcd"
 	"github.com/openimsdk/tools/utils/datautil"
-	"github.com/openimsdk/tools/utils/jsonutil"
 	"google.golang.org/grpc/status"
 
 	kdisc "github.com/openimsdk/open-im-server/v3/pkg/common/discoveryregister"
@@ -118,10 +117,7 @@ func Start[T any](ctx context.Context, discovery *conf.Discovery, prometheusConf
 
 			etcdClient := client.(*etcd.SvcDiscoveryRegistryImpl).GetClient()
 
-			_, err = etcdClient.Put(ctx, prommetrics.BuildDiscoveryKey(rpcRegisterName), jsonutil.StructToJsonString(prommetrics.BuildDefaultTarget(registerIP, prometheusPort)))
-			if err != nil {
-				return errs.WrapMsg(err, "etcd put err")
-			}
+			prommetrics.Register(ctx, etcdClient, rpcRegisterName, registerIP, prometheusPort)
 		} else {
 			prometheusPort, err = datautil.GetElemByIndex(prometheusConfig.Ports, index)
 			if err != nil {


### PR DESCRIPTION
Fixes #3073 

**Description**
When setAutoPorts enabled, if starting two rpc service (e.g. user rpc service) , the second one will overwrite the etcd value with same key, the code in start.go as below
```go
if autoSetPorts {
	listener, prometheusPort, err = getAutoPort()
	if err != nil {
		return err
	}

	etcdClient := client.(*etcd.SvcDiscoveryRegistryImpl).GetClient()
        // this step will overwrtite the same service with different value
	_, err = etcdClient.Put(ctx, prommetrics.BuildDiscoveryKey(rpcRegisterName), jsonutil.StructToJsonString(prommetrics.BuildDefaultTarget(registerIP, prometheusPort)))
	if err != nil {
		return errs.WrapMsg(err, "etcd put err")
	}
}
```
For example, I started user service, the etcd value like
```
openim/prometheus_discovery/user {"target":"10.102.22.175:40145","labels":{"namespace":"default"}}
```
if I started another user service in different node, the etcd value was covered
```
openim/prometheus_discovery/user {"target":"/168.64.9.42:34657","labels":{"namespace":"default"}}
```
**Fixed**
Add nodeId and port in etcd key, the value will be like this in same scenario
```
openim/prometheus_discovery/user/10.102.22.175:40145 {"target":"10.102.22.175:40145","labels":{"namespace":"default"}}
openim/prometheus_discovery/user/168.64.9.42:34657 {"target":"/168.64.9.42:34657","labels":{"namespace":"default"}}
```

Moreover, the prometheus discovery will return correct node instances,
```
[
    {
        "targets": [
            "10.102.22.175:40145",
            "168.64.9.42:34657"
        ],
        "labels": {
            "namespace": "default"
        }
    }
]
```