### PR TITLE
Fixed the issue where multiple terminals may log in using the same token

### DIFF
--- a/internal/msggateway/ws_server.go
+++ b/internal/msggateway/ws_server.go
@@ -323,6 +323,7 @@ func (ws *WsServer) multiTerminalLoginChecker(clientOK bool, oldClients []*Clien
 			// During this process, instance A might still be executing, resulting in two clients with the same token existing simultaneously.
 			// This situation needs to be filtered to prevent duplicate clients.
 			if c.token == newClient.token {
+				log.ZDebug(newClient.ctx, "token is same, not kick", "userID", newClient.UserID, "platformID", newClient.PlatformID, "token", newClient.token)
 				continue
 			}
 			kickTokens = append(kickTokens, c.token)


### PR DESCRIPTION
#3575  🅰 Please add the issue ID after "Fixes #"

Fixes #

When the app changes its connection from server A to server B, the memory allocated for the old connection in server A is not reclaimed.

Related bug: https://github.com/openimsdk/open-im-server/issues/3449

Scenario:

multiple terminals may log in using the same token