### PR TITLE
fix: Mongo Malloc upsert overwrites min_seq initialization

### DIFF
--- a/pkg/common/storage/database/mgo/seq_conversation.go
+++ b/pkg/common/storage/database/mgo/seq_conversation.go
@@ -57,8 +57,8 @@ func (s *seqConversationMongo) Malloc(ctx context.Context, conversationID string
 	}
 	filter := map[string]any{"conversation_id": conversationID}
 	update := map[string]any{
-		"$inc": map[string]any{"max_seq": size},
-		"$set": map[string]any{"min_seq": int64(0)},
+		"$inc":         map[string]any{"max_seq": size},
+		"$setOnInsert": map[string]any{"min_seq": int64(0)},
 	}
 	opt := options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After).SetProjection(map[string]any{"_id": 0, "max_seq": 1})
 	lastSeq, err := mongoutil.FindOneAndUpdate[int64](ctx, s.coll, filter, update, opt)


### PR DESCRIPTION
(cherry picked from commit c27d33160f167a7d967f9d1cb74a6b48c5e44ca9)


## 🅰 Please add the issue ID after "Fixes #"

Fixes #3656 
