### PR TITLE
fix: join group

### DIFF
--- a/internal/rpc/group/callback.go
+++ b/internal/rpc/group/callback.go
@@ -283,6 +283,7 @@ func (g *groupServer) webhookAfterJoinGroup(ctx context.Context, after *config.A
 		ReqMessage:      req.ReqMessage,
 		JoinSource:      req.JoinSource,
 		InviterUserID:   req.InviterUserID,
+		Ex:              req.Ex,
 	}
 	g.webhookClient.AsyncPost(ctx, cbReq.GetCallbackCommand(), cbReq, &callbackstruct.CallbackAfterJoinGroupResp{}, after)
 }

--- a/internal/rpc/group/group.go
+++ b/internal/rpc/group/group.go
@@ -960,6 +960,8 @@ func (g *groupServer) JoinGroup(ctx context.Context, req *pbgroup.JoinGroupReq) 
 			InviterUserID:  req.InviterUserID,
 			JoinTime:       time.Now(),
 			MuteEndTime:    time.UnixMilli(0),
+			JoinSource:     req.JoinSource,
+			Ex:             req.Ex,
 		}
 
 		if err := g.webhookBeforeMembersJoinGroup(ctx, &g.config.WebhooksConfig.BeforeMemberJoinGroup, []*model.GroupMember{groupMember}, group.GroupID, group.Ex); err != nil && err != servererrs.ErrCallbackContinue {

--- a/pkg/callbackstruct/group.go
+++ b/pkg/callbackstruct/group.go
@@ -194,6 +194,7 @@ type CallbackAfterJoinGroupReq struct {
 	ReqMessage      string `json:"reqMessage"`
 	JoinSource      int32  `json:"joinSource"`
 	InviterUserID   string `json:"inviterUserID"`
+	Ex              string `json:"ex"`
 }
 type CallbackAfterJoinGroupResp struct {
 	CommonCallbackResp


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes # 
When applying to join the group, the group members did not save the joining method, and the method did not return the ex field after the join callback.
