### PR TITLE
fix: remove duplicate conversation_id unique index

### DIFF
--- a/pkg/common/storage/database/mgo/conversation.go
+++ b/pkg/common/storage/database/mgo/conversation.go
@@ -47,12 +47,6 @@ func NewConversationMongo(db *mongo.Database) (*ConversationMgo, error) {
 			},
 			Options: options.Index(),
 		},
-		{
-			Keys: bson.D{
-				{Key: "conversation_id", Value: 1},
-			},
-			Options: options.Index().SetUnique(true),
-		},
 	})
 	if err != nil {
 		return nil, errs.Wrap(err)


### PR DESCRIPTION
## Summary
- remove the global unique index on `conversation_id` from the conversation mongo initialization
- keep the existing unique constraint on `owner_user_id` + `conversation_id`
- prevent duplicate key failures when creating group conversations for multiple owners

## Test plan
- [x] start the server against a clean mongo database
- [ ] create a group and send the first group message
- [ ] verify `CreateGroupChatConversations` no longer fails with `E11000` on `conversation_id_1`

Made with [Cursor](https://cursor.com)