### PR TITLE
pkg/tools/batcher: stop scheduler panicking when b.data is closed externally

### DIFF
--- a/pkg/tools/batcher/batcher.go
+++ b/pkg/tools/batcher/batcher.go
@@ -151,12 +151,21 @@ func (b *Batcher[T]) Put(ctx context.Context, data *T) error {
 
 func (b *Batcher[T]) scheduler() {
 	ticker := time.NewTicker(b.config.interval)
+	// Track whether b.data was closed by an external caller so the
+	// cleanup below does not close it a second time. The only routes
+	// out of this function that leave b.data open are the nil-message
+	// and ticker paths; the ok == false branch means someone already
+	// closed the channel, and calling close(b.data) again there would
+	// panic with "close of closed channel" (#3653).
+	externallyClosed := false
 	defer func() {
 		ticker.Stop()
 		for _, ch := range b.chArrays {
 			close(ch)
 		}
-		close(b.data)
+		if !externallyClosed {
+			close(b.data)
+		}
 		b.wait.Done()
 	}()
 
@@ -169,6 +178,7 @@ func (b *Batcher[T]) scheduler() {
 		case data, ok := <-b.data:
 			if !ok {
 				// If the data channel is closed unexpectedly
+				externallyClosed = true
 				return
 			}
 			if data == nil {


### PR DESCRIPTION
Fixes #3653.

`scheduler()`'s defer unconditionally calls `close(b.data)`. If the channel was closed by the caller (or an upstream producer) instead of via the normal `Close()`-sends-nil path, the receive on `b.data` returns `ok == false`, `scheduler` returns, and the deferred `close(b.data)` then fires on an already-closed channel:

```
panic: close of closed channel
```

reliably reproducible under the issue's steps (manually closing `b.data` while `Start()` is running).

This tracks whether we observed the external-close via a local `externallyClosed` flag set in the `ok == false` branch. The defer only closes `b.data` when that flag is false, i.e. when the scheduler exited through the nil-message or ticker paths and still owns the channel. No behaviour change on the graceful `Close()` path.