### PR TITLE
fix: update regex pattern for conversationID to include a trailing colon

### DIFF
--- a/pkg/common/storage/database/mgo/msg.go
+++ b/pkg/common/storage/database/mgo/msg.go
@@ -956,7 +956,7 @@ func (m *MsgMgo) GetLastMessageSeqByTime(ctx context.Context, conversationID str
 		{
 			"$match": bson.M{
 				"doc_id": bson.M{
-					"$regex": fmt.Sprintf("^%s", conversationID),
+					"$regex": fmt.Sprintf("^%s:", conversationID),
 				},
 			},
 		},
@@ -1008,7 +1008,7 @@ func (m *MsgMgo) GetLastMessage(ctx context.Context, conversationID string) (*mo
 		{
 			"$match": bson.M{
 				"doc_id": bson.M{
-					"$regex": fmt.Sprintf("^%s", conversationID),
+					"$regex": fmt.Sprintf("^%s:", conversationID),
 				},
 			},
 		},


### PR DESCRIPTION
…railing colon

(cherry picked from commit 82f87551d6067983f4e31f8dacb905c740d58639)


## 🅰 Please add the issue ID after "Fixes #"

Fixes #3734 
