### PR TITLE
perf(cache): fix slice capacity under-allocation in SetUserOnline

### DIFF
--- a/pkg/common/storage/cache/redis/online.go
+++ b/pkg/common/storage/cache/redis/online.go
@@ -112,7 +112,7 @@ func (s *userOnline) SetUserOnline(ctx context.Context, userID string, online, o
 	end
 `
 	now := time.Now()
-	argv := make([]any, 0, 2+len(online)+len(offline))
+	argv := make([]any, 0, 4+len(online)+len(offline))
 	argv = append(argv, int32(s.expire/time.Second), now.Unix(), now.Add(s.expire).Unix(), int32(len(offline)))
 	for _, platformID := range offline {
 		argv = append(argv, platformID)


### PR DESCRIPTION
The `argv` slice was initialized with a capacity of 2, but 4 metadata 
parameters were immediately appended. This caused an unnecessary 
reallocation on every status update.

Corrected the initial capacity to 4 to avoid extra memory allocation 
in the high-concurrency online status sync path.