### PR TITLE
fix(msggateway): preserve client background status

### DIFF
--- a/internal/msggateway/client.go
+++ b/internal/msggateway/client.go
@@ -91,7 +91,6 @@ func (c *Client) ResetClient(ctx *UserConnContext, conn ClientConn, longConnServ
 	c.UserID = ctx.GetUserID()
 	c.ctx = ctx
 	c.longConnServer = longConnServer
-	c.IsBackground = false
 	c.closed.Store(false)
 	c.closedErr = nil
 	c.token = ctx.GetToken()


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #

## Summary

`ResetClient` reads the background status from the connection context, but then immediately overwrites it with `false`.

This causes the handshake `isBackground` value to be ignored. For example, an iOS client that connects while in background can be treated as foreground, so `pushToUser` may attempt WebSocket online push instead of returning the iOS background push result.

This change removes the forced reset and keeps the background status parsed from the handshake.