### PR TITLE
fix(msggateway): avoid closed channel panic in super group push

### DIFF
--- a/internal/msggateway/hub_server.go
+++ b/internal/msggateway/hub_server.go
@@ -175,22 +175,22 @@ func (s *Server) SuperGroupOnlineBatchPushOneMsg(ctx context.Context, req *msgga
 	ch := make(chan *msggateway.SingleMsgToUserResults, len(req.PushToUserIDs))
 	var count atomic.Int64
 	count.Add(int64(len(req.PushToUserIDs)))
+	pushResult := func(result *msggateway.SingleMsgToUserResults) {
+		ch <- result
+		if count.Add(-1) == 0 {
+			close(ch)
+		}
+	}
 	for i := range req.PushToUserIDs {
 		userID := req.PushToUserIDs[i]
 		err := s.queue.PushCtx(ctx, func() {
-			ch <- s.pushToUser(ctx, userID, req.MsgData)
-			if count.Add(-1) == 0 {
-				close(ch)
-			}
+			pushResult(s.pushToUser(ctx, userID, req.MsgData))
 		})
 		if err != nil {
-			if count.Add(-1) == 0 {
-				close(ch)
-			}
 			log.ZError(ctx, "pushToUser MemoryQueue failed", err, "userID", userID)
-			ch <- &msggateway.SingleMsgToUserResults{
+			pushResult(&msggateway.SingleMsgToUserResults{
 				UserID: userID,
-			}
+			})
 		}
 	}
 	resp := &msggateway.OnlineBatchPushOneMsgResp{


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #

## Summary

Fix a panic risk in `SuperGroupOnlineBatchPushOneMsg` when queue enqueue fails.

## Problem

`SuperGroupOnlineBatchPushOneMsg` uses a result channel to collect per-user push results and closes the channel when all pending users are handled.

In the `PushCtx` error branch, the previous code decremented the pending counter and could close the result channel before sending the fallback result. If the failed enqueue was the last pending item, the following send would panic:

```text
panic: send on closed channel
```

This can happen on abnormal paths such as request context cancellation while the in-memory queue is unable to accept another task, or when the queue has already stopped.

## Changes

- Centralized result sending and completion accounting in `pushResult`.
- Ensured both success and `PushCtx` error paths send the user result before decrementing the pending counter.
- Kept the last completed sender responsible for closing the result channel.
