### PR TITLE
fix(msggateway): avoid reusing Clients backing array

### DIFF
--- a/internal/msggateway/user_map.go
+++ b/internal/msggateway/user_map.go
@@ -1,9 +1,10 @@
 package msggateway
 
 import (
-	"github.com/openimsdk/tools/utils/datautil"
 	"sync"
 	"time"
+
+	"github.com/openimsdk/tools/utils/datautil"
 )
 
 type UserMap interface {
@@ -146,7 +147,7 @@ func (u *userMap) DeleteClients(userID string, clients []*Client) (isDeleteUser 
 		return client.ctx.GetRemoteAddr()
 	})
 	tmp := result.Clients
-	result.Clients = result.Clients[:0]
+	result.Clients = result.Clients[:0:0]
 	for _, client := range tmp {
 		if _, delCli := deleteAddr[client.ctx.GetRemoteAddr()]; delCli {
 			offline = append(offline, int32(client.PlatformID))


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #

## Summary

Fix `UserMap.DeleteClients` to avoid overwriting client slices that were previously returned by `GetAll`.

## Problem

`DeleteClients` used `result.Clients[:0]` before rebuilding the remaining client list. This preserves the original capacity, so subsequent `append` calls reuse and overwrite the same backing array.

Callers such as RPC push or multi-login checks may already hold a slice returned by `GetAll` and iterate it after `UserMap` releases its lock. When `DeleteClients` runs concurrently, those callers can observe mutated slice contents, for example `[A, B, C]` becoming `[B, C, C]`.

## Changes

Use `result.Clients[:0:0]` so the rebuilt client list gets a new backing array while keeping the existing filtering logic unchanged.