### PR TITLE
fix(docker): pin base image versions for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG RELEASE=false
 ARG COMPRESS=false
@@ -13,7 +13,7 @@ RUN go mod download
 RUN RELEASE=${RELEASE} COMPRESS=${COMPRESS} mage build
 RUN mage -compile ./mage -ldflags "-s -w"
 
-FROM alpine:latest
+FROM alpine:3.23
 
 WORKDIR /openim-server
 


### PR DESCRIPTION
## Problem

The Dockerfile relies on floating image tags — `golang:alpine` for the build stage and `alpine:latest` for the runtime stage. This causes:

1. **Non-reproducible builds** — the same commit can build against a different Go toolchain or base image depending on when it's built.
2. **Drift from `go.mod`** — `go.mod` declares `go 1.25.0`, but `golang:alpine` tracks the latest stable Go, which can move past 1.25 and trigger toolchain downloads or subtle behavior changes.
3. **Supply-chain risk** — floating tags (especially `:latest`) are a common vector for tag-replay/mutability attacks.

## Changes

| Stage   | Before          | After                 |
|---------|-----------------|-----------------------|
| builder | `golang:alpine` | `golang:1.25-alpine`  |
| runtime | `alpine:latest` | `alpine:3.23`         |

## Rationale

- `golang:1.25-alpine` aligns the build toolchain with the `go 1.25.0` declared in `go.mod`, keeping builds deterministic and reproducible.
- `alpine:3.23` is the current stable Alpine series. Pinning the minor (rather than `latest`) still receives security patches within the series while preventing unexpected jumps to a new minor.

## Notes

- This is an improvement, not a bugfix: the current image builds successfully, but the floating tags make the result non-reproducible.
- No functional or code changes; only base-image tags are pinned.
